### PR TITLE
Update DatabaseReader.cs

### DIFF
--- a/GeoIP2/DatabaseReader.cs
+++ b/GeoIP2/DatabaseReader.cs
@@ -90,7 +90,7 @@ namespace MaxMind.GeoIP2
             var token = _reader.Find(ipAddress);
 
             if (token == null)
-                throw new AddressNotFoundException("The address " + ipAddress + " is not in the database.");
+                return default(T);
 
             JObject ipObject;
             if (hasTraits)


### PR DESCRIPTION
A non exisiting IP shouldn't throw an exception. It is a normal control flow for an IP not to be in the database. It should be handled gracefully by returning a default value, instead of throwing an exception.
