### PR TITLE
Added explicit JsonIgnore attribute

### DIFF
--- a/GeoIP2/Model/NamedEntity.cs
+++ b/GeoIP2/Model/NamedEntity.cs
@@ -36,6 +36,7 @@ namespace MaxMind.GeoIP2.Model
         /// <summary>
         /// A <see cref="System.Collections.Generic.Dictionary{T,U}"/> from locale codes to the name in that locale.
         /// </summary>
+        [JsonIgnore]
         public Dictionary<string, string> Names
         {
             get { return new Dictionary<string, string>(_names); }

--- a/GeoIP2/Responses/AbstractCityResponse.cs
+++ b/GeoIP2/Responses/AbstractCityResponse.cs
@@ -72,6 +72,7 @@ namespace MaxMind.GeoIP2.Responses
         /// If the response did not contain any subdivisions, this method
         /// returns an empty array.
         /// </summary>
+        [JsonIgnore]
         public List<Subdivision> Subdivisions
         {
             get { return new List<Subdivision>(_subdivisions); }


### PR DESCRIPTION
... to fields with private/internal setters when they have backing fields annotated with the same name. 
i.e. public Dictionary Names and _names exposed as "Names" via JsonProperty attribute.

This is because JSON.NET can be configured to expose non-public fields and in this scenario an exception is thrown when another property with the same name is added to the JObject.