### PR TITLE
Adding HasCoorindates getter with associated unit tests

### DIFF
--- a/GeoIP2.UnitTests/GeoIP2.UnitTests.csproj
+++ b/GeoIP2.UnitTests/GeoIP2.UnitTests.csproj
@@ -59,6 +59,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Model\LocationTests.cs" />
     <Compile Include="ResponseTests.cs" />
     <Compile Include="DatabaseReaderTests.cs" />
     <Compile Include="DeserializationTests.cs" />

--- a/GeoIP2.UnitTests/Model/LocationTests.cs
+++ b/GeoIP2.UnitTests/Model/LocationTests.cs
@@ -1,0 +1,28 @@
+﻿using MaxMind.GeoIP2.Model;
+using NUnit.Framework;
+
+namespace MaxMind.GeoIP2.UnitTests.Model
+{
+    [TestFixture]
+    public class LocationTests
+    {
+        [Test]
+        public void HasCoordinatesSuccess()
+        {
+            var location = new Location(latitude: 50.0, longitude: 0.0);
+            Assert.IsTrue(location.HasCoordinates);
+        }
+
+        [Test]
+        [TestCase(null, null)]
+        [TestCase(50.0, null)]
+        [TestCase(null, 0.0)]
+        public void HasCoordinatesFailure(double? latitude, double? longitude)
+        {
+            var location = new Location
+                (latitude: latitude, longitude: longitude);
+
+            Assert.IsFalse(location.HasCoordinates);
+        }
+    }
+}

--- a/GeoIP2/Model/Location.cs
+++ b/GeoIP2/Model/Location.cs
@@ -33,6 +33,15 @@ namespace MaxMind.GeoIP2.Model
         public int? AccuracyRadius { get; internal set; }
 
         /// <summary>
+        /// Determines whether both the <see cref="Latitude">latitude</see>
+        /// and <see cref="Longitude">longitude</see> have values.
+        /// </summary>
+        public bool HasCoordinates
+        {
+            get { return Latitude.HasValue && Longitude.HasValue; }
+        }
+
+        /// <summary>
         /// The latitude of the location as a floating point number.
         /// </summary>
         [JsonProperty("latitude")]


### PR DESCRIPTION
Hi,

In a current project, we have needed to check that both co-ordinates of a Location are set before using it.

Rather than just check both values, or use a custom extension method, I thought I would add a getter to the class itself and submit this pull request!

Thanks,
Darren