### PR TITLE
Reflect field rename in API

### DIFF
--- a/GeoIP2.UnitTests/DeserializationTests.cs
+++ b/GeoIP2.UnitTests/DeserializationTests.cs
@@ -62,7 +62,7 @@ namespace MaxMind.GeoIP2.UnitTests
             Assert.AreEqual(765, insights.Location.MetroCode);
             Assert.AreEqual("America/Chicago", insights.Location.TimeZone);
             Assert.AreEqual(50000, insights.Location.AverageIncome);
-            Assert.AreEqual(100, insights.Location.EstimatedPopulation);
+            Assert.AreEqual(100, insights.Location.PopulationDensity);
 
             Assert.AreEqual(11, insights.MaxMind.QueriesRemaining);
 

--- a/GeoIP2.UnitTests/ResponseHelper.cs
+++ b/GeoIP2.UnitTests/ResponseHelper.cs
@@ -51,10 +51,10 @@ namespace MaxMind.GeoIP2.UnitTests
                 {
                     {"accuracy_radius", 1500},
                     {"average_income", 50000 },
-                    {"estimated_population", 100 },
                     {"latitude", 44.98},
                     {"longitude", 93.2636},
                     {"metro_code", 765},
+                    {"population_density", 100 },
                     {"time_zone", "America/Chicago"}
                 }
             },

--- a/GeoIP2.UnitTests/WebServiceClientTests.cs
+++ b/GeoIP2.UnitTests/WebServiceClientTests.cs
@@ -261,7 +261,7 @@ namespace MaxMind.GeoIP2.UnitTests
             Assert.IsNull(location.Longitude);
             Assert.IsNull(location.MetroCode);
             Assert.IsNull(location.TimeZone);
-            Assert.IsNull(location.EstimatedPopulation);
+            Assert.IsNull(location.PopulationDensity);
             Assert.IsNull(location.AverageIncome);
 
             var maxmind = insights.MaxMind;

--- a/GeoIP2/Model/Location.cs
+++ b/GeoIP2/Model/Location.cs
@@ -36,7 +36,7 @@ namespace MaxMind.GeoIP2.Model
         public int? AccuracyRadius { get; internal set; }
 
         /// <summary>
-        ///     The average income per household in US dollars.
+        ///     The average income in US dollars associated with the IP address.
         /// </summary>
         [JsonProperty("average_income")]
         public int? AverageIncome { get; internal set; }
@@ -47,12 +47,6 @@ namespace MaxMind.GeoIP2.Model
         /// </summary>
         [JsonIgnore]
         public bool HasCoordinates => Latitude.HasValue && Longitude.HasValue;
-
-        /// <summary>
-        ///     The estimated number of people per square kilometer.	
-        /// </summary>
-        [JsonProperty("estimated_population")]
-        public int? EstimatedPopulation { get; internal set; }
 
         /// <summary>
         ///     The latitude of the location as a floating point number.
@@ -73,6 +67,12 @@ namespace MaxMind.GeoIP2.Model
         /// </summary>
         [JsonProperty("metro_code")]
         public int? MetroCode { get; internal set; }
+
+        /// <summary>
+        ///     The estimated number of people per square kilometer.
+        /// </summary>
+        [JsonProperty("population_density")]
+        public int? PopulationDensity { get; internal set; }
 
         /// <summary>
         ///     The time zone associated with location, as specified by the

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -4,7 +4,7 @@ GeoIP2 .NET API Release Notes
 2.3.0 (2015-XX-XX)
 ------------------
 
-* `AverageIncome` and `EstimatePopulation` were added to the `Location`
+* `AverageIncome` and `PopulationDensity` were added to the `Location`
   model for use with the new fields in GeoIP2 Insights.
 * `IsAnonymousProxy` and `IsSatelliteProvider` in `GeoIP2.Model.Traits` have
   been deprecated. Please use our [GeoIP2 Anonymous IP


### PR DESCRIPTION
The internal developmental version of the API had a field rename, so before anything goes live we're updating the client API also