### PR TITLE
Update for current RestSharp version

### DIFF
--- a/GeoIP2.UnitTests/GeoIP2.UnitTests.csproj
+++ b/GeoIP2.UnitTests/GeoIP2.UnitTests.csproj
@@ -45,9 +45,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="RestSharp, Version=105.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\RestSharp.105.1.0\lib\net4\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.105.2.3\lib\net4\RestSharp.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Rhino.Mocks">
       <HintPath>..\packages\RhinoMocks.3.6.1\lib\net\Rhino.Mocks.dll</HintPath>

--- a/GeoIP2.UnitTests/packages.config
+++ b/GeoIP2.UnitTests/packages.config
@@ -3,6 +3,6 @@
   <package id="MaxMind.Db" version="1.1.0" targetFramework="net4" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net4" />
   <package id="NUnit" version="2.6.4" targetFramework="net4" />
-  <package id="RestSharp" version="105.1.0" targetFramework="net4" />
+  <package id="RestSharp" version="105.2.3" targetFramework="net4" />
   <package id="RhinoMocks" version="3.6.1" targetFramework="net4" />
 </packages>

--- a/GeoIP2/GeoIP2.csproj
+++ b/GeoIP2/GeoIP2.csproj
@@ -45,9 +45,9 @@
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="RestSharp, Version=105.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\RestSharp.105.1.0\lib\net4\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.105.2.3\lib\net4\RestSharp.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/GeoIP2/WebServiceClient.cs
+++ b/GeoIP2/WebServiceClient.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Reflection;
 using System.Runtime.Serialization;
+using RestSharp.Authenticators;
 
 namespace MaxMind.GeoIP2
 {

--- a/GeoIP2/packages.config
+++ b/GeoIP2/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="MaxMind.Db" version="1.1.0" targetFramework="net4" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net4" />
-  <package id="RestSharp" version="105.1.0" targetFramework="net4" />
+  <package id="RestSharp" version="105.2.3" targetFramework="net4" />
 </packages>


### PR DESCRIPTION
As discussed in my posted issue (https://github.com/maxmind/GeoIP2-dotnet/issues/33)  the current version causes an exception of type: Could not load type 'RestSharp.HttpBasicAuthenticator' from assembly 'RestSharp, Version=105.2.2.0, Culture=neutral, PublicKeyToken=null'.":"RestSharp.HttpBasicAuthenticator"}.

This is caused by internal restructuring in the RestSharp library that makes it incompatible with the previous version that the GeoIP2 library was built against.

This simple pull requests updates and verifies against the most current RestSharp library (105.2.3)