### PR TITLE
Try based lookup methods

### DIFF
--- a/GeoIP2.UnitTests/DatabaseReaderTests.cs
+++ b/GeoIP2.UnitTests/DatabaseReaderTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Reflection;
+using MaxMind.GeoIP2.Responses;
 
 #endregion
 
@@ -136,6 +137,19 @@ namespace MaxMind.GeoIP2.UnitTests
         }
 
         [Test]
+        public void TestTryCountry()
+        {
+            using (var reader = new DatabaseReader(Path.Combine(_databaseDir, "GeoIP2-Country-Test.mmdb")))
+            {
+                CountryResponse response;
+                var status = reader.TryCountry("81.2.69.160", out response);
+
+                Assert.IsTrue(status);
+                Assert.That(response.Country.IsoCode, Is.EqualTo("GB"));
+            }
+        }
+
+        [Test]
         public void TestDefaultLocale()
         {
             using (var reader = new DatabaseReader(_databaseFile))
@@ -196,6 +210,18 @@ namespace MaxMind.GeoIP2.UnitTests
                 Assert.Throws(Is.TypeOf<AddressNotFoundException>()
                     .And.Message.Contains("10.10.10.10 is not in the database"),
                     () => reader.City("10.10.10.10"));
+            }
+        }
+
+        [Test]
+        public void TryCityUnknownAddress()
+        {
+            using (var reader = new DatabaseReader(_databaseFile))
+            {
+                CityResponse response;
+                var status = reader.TryCity("10.10.10.10", out response);
+
+                Assert.IsFalse(status);
             }
         }
     }

--- a/GeoIP2/DatabaseReader.cs
+++ b/GeoIP2/DatabaseReader.cs
@@ -189,9 +189,31 @@ namespace MaxMind.GeoIP2
         /// </summary>
         /// <param name="ipAddress">The IP address.</param>
         /// <returns>An <see cref="AnonymousIPResponse" /></returns>
+        public AnonymousIPResponse AnonymousIP(IPAddress ipAddress)
+        {
+            return Execute<AnonymousIPResponse>(ipAddress, "GeoIP2-Anonymous-IP");
+        }
+
+        /// <summary>
+        ///     Look up an IP address in a GeoIP2 Anonymous IP.
+        /// </summary>
+        /// <param name="ipAddress">The IP address.</param>
+        /// <returns>An <see cref="AnonymousIPResponse" /></returns>
         public AnonymousIPResponse AnonymousIP(string ipAddress)
         {
             return Execute<AnonymousIPResponse>(ipAddress, "GeoIP2-Anonymous-IP");
+        }
+
+        /// <summary>
+        ///     Tries to lookup an <see cref="AnonymousIPResponse" /> for the specified IP address.
+        /// </summary>
+        /// <param name="ipAddress">The IP address.</param>
+        /// <param name="response">The <see cref="AnonymousIPResponse" />.</param>
+        /// <returns>A <see cref="bool" /> describing whether the IP address was found.</returns>
+        public bool TryAnonymousIP(IPAddress ipAddress, out AnonymousIPResponse response)
+        {
+            response = Execute<AnonymousIPResponse>(ipAddress, "GeoIP2-Anonymous-IP", false);
+            return response != null;
         }
 
         /// <summary>
@@ -211,9 +233,31 @@ namespace MaxMind.GeoIP2
         /// </summary>
         /// <param name="ipAddress">The IP address.</param>
         /// <returns>An <see cref="ConnectionTypeResponse" /></returns>
+        public ConnectionTypeResponse ConnectionType(IPAddress ipAddress)
+        {
+            return Execute<ConnectionTypeResponse>(ipAddress, "GeoIP2-Connection-Type");
+        }
+
+        /// <summary>
+        ///     Returns an <see cref="ConnectionTypeResponse" /> for the specified IP address.
+        /// </summary>
+        /// <param name="ipAddress">The IP address.</param>
+        /// <returns>An <see cref="ConnectionTypeResponse" /></returns>
         public ConnectionTypeResponse ConnectionType(string ipAddress)
         {
             return Execute<ConnectionTypeResponse>(ipAddress, "GeoIP2-Connection-Type");
+        }
+
+        /// <summary>
+        ///     Tries to lookup a <see cref="ConnectionTypeResponse" /> for the specified IP address.
+        /// </summary>
+        /// <param name="ipAddress">The IP address.</param>
+        /// <param name="response">The <see cref="ConnectionTypeResponse" />.</param>
+        /// <returns>A <see cref="bool" /> describing whether the IP address was found.</returns>
+        public bool TryConnectionType(IPAddress ipAddress, out ConnectionTypeResponse response)
+        {
+            response = Execute<ConnectionTypeResponse>(ipAddress, "GeoIP2-Connection-Type", false);
+            return response != null;
         }
 
         /// <summary>
@@ -233,9 +277,31 @@ namespace MaxMind.GeoIP2
         /// </summary>
         /// <param name="ipAddress">The IP address.</param>
         /// <returns>An <see cref="DomainResponse" /></returns>
+        public DomainResponse Domain(IPAddress ipAddress)
+        {
+            return Execute<DomainResponse>(ipAddress, "GeoIP2-Domain");
+        }
+
+        /// <summary>
+        ///     Returns an <see cref="DomainResponse" /> for the specified IP address.
+        /// </summary>
+        /// <param name="ipAddress">The IP address.</param>
+        /// <returns>An <see cref="DomainResponse" /></returns>
         public DomainResponse Domain(string ipAddress)
         {
             return Execute<DomainResponse>(ipAddress, "GeoIP2-Domain");
+        }
+
+        /// <summary>
+        ///     Tries to lookup a <see cref="DomainResponse" /> for the specified IP address.
+        /// </summary>
+        /// <param name="ipAddress">The IP address.</param>
+        /// <param name="response">The <see cref="DomainResponse" />.</param>
+        /// <returns>A <see cref="bool" /> describing whether the IP address was found.</returns>
+        public bool TryDomain(IPAddress ipAddress, out DomainResponse response)
+        {
+            response = Execute<DomainResponse>(ipAddress, "GeoIP2-Domain", false);
+            return response != null;
         }
 
         /// <summary>
@@ -255,9 +321,31 @@ namespace MaxMind.GeoIP2
         /// </summary>
         /// <param name="ipAddress">The IP address.</param>
         /// <returns>An <see cref="IspResponse" /></returns>
+        public IspResponse Isp(IPAddress ipAddress)
+        {
+            return Execute<IspResponse>(ipAddress, "GeoIP2-ISP");
+        }
+
+        /// <summary>
+        ///     Returns an <see cref="IspResponse" /> for the specified IP address.
+        /// </summary>
+        /// <param name="ipAddress">The IP address.</param>
+        /// <returns>An <see cref="IspResponse" /></returns>
         public IspResponse Isp(string ipAddress)
         {
             return Execute<IspResponse>(ipAddress, "GeoIP2-ISP");
+        }
+
+        /// <summary>
+        ///     Tries to lookup an <see cref="IspResponse" /> for the specified IP address.
+        /// </summary>
+        /// <param name="ipAddress">The IP address.</param>
+        /// <param name="response">The <see cref="IspResponse" />.</param>
+        /// <returns>A <see cref="bool" /> describing whether the IP address was found.</returns>
+        public bool TryIsp(IPAddress ipAddress, out IspResponse response)
+        {
+            response = Execute<IspResponse>(ipAddress, "GeoIP2-ISP", false);
+            return response != null;
         }
 
         /// <summary>
@@ -313,46 +401,6 @@ namespace MaxMind.GeoIP2
             response.SetLocales(_locales);
 
             return response;
-        }
-
-        /// <summary>
-        ///     Look up an IP address in a GeoIP2 Anonymous IP.
-        /// </summary>
-        /// <param name="ipAddress">The IP address.</param>
-        /// <returns>An <see cref="AnonymousIPResponse" /></returns>
-        public AnonymousIPResponse AnonymousIP(IPAddress ipAddress)
-        {
-            return Execute<AnonymousIPResponse>(ipAddress, "GeoIP2-Anonymous-IP");
-        }
-
-        /// <summary>
-        ///     Returns an <see cref="ConnectionTypeResponse" /> for the specified IP address.
-        /// </summary>
-        /// <param name="ipAddress">The IP address.</param>
-        /// <returns>An <see cref="ConnectionTypeResponse" /></returns>
-        public ConnectionTypeResponse ConnectionType(IPAddress ipAddress)
-        {
-            return Execute<ConnectionTypeResponse>(ipAddress, "GeoIP2-Connection-Type");
-        }
-
-        /// <summary>
-        ///     Returns an <see cref="DomainResponse" /> for the specified IP address.
-        /// </summary>
-        /// <param name="ipAddress">The IP address.</param>
-        /// <returns>An <see cref="DomainResponse" /></returns>
-        public DomainResponse Domain(IPAddress ipAddress)
-        {
-            return Execute<DomainResponse>(ipAddress, "GeoIP2-Domain");
-        }
-
-        /// <summary>
-        ///     Returns an <see cref="IspResponse" /> for the specified IP address.
-        /// </summary>
-        /// <param name="ipAddress">The IP address.</param>
-        /// <returns>An <see cref="IspResponse" /></returns>
-        public IspResponse Isp(IPAddress ipAddress)
-        {
-            return Execute<IspResponse>(ipAddress, "GeoIP2-ISP");
         }
     }
 }

--- a/GeoIP2/DatabaseReader.cs
+++ b/GeoIP2/DatabaseReader.cs
@@ -117,6 +117,30 @@ namespace MaxMind.GeoIP2
         }
 
         /// <summary>
+        ///     Tries to lookup a <see cref="CountryResponse" /> for the specified IP address.
+        /// </summary>
+        /// <param name="ipAddress">The IP address.</param>
+        /// <param name="response">The <see cref="CountryResponse" />.</param>
+        /// <returns>A <see cref="bool" /> describing whether the IP address was found.</returns>
+        public bool TryCountry(IPAddress ipAddress, out CountryResponse response)
+        {
+            response = Execute<CountryResponse>(ipAddress, "Country", false);
+            return response != null;
+        }
+
+        /// <summary>
+        ///     Tries to lookup a <see cref="CountryResponse" /> for the specified IP address.
+        /// </summary>
+        /// <param name="ipAddress">The IP address.</param>
+        /// <param name="response">The <see cref="CountryResponse" />.</param>
+        /// <returns>A <see cref="bool" /> describing whether the IP address was found.</returns>
+        public bool TryCountry(string ipAddress, out CountryResponse response)
+        {
+            response = Execute<CountryResponse>(ipAddress, "Country", false);
+            return response != null;
+        }
+
+        /// <summary>
         ///     Returns an <see cref="CityResponse" /> for the specified IP address.
         /// </summary>
         /// <param name="ipAddress">The IP address.</param>
@@ -134,6 +158,30 @@ namespace MaxMind.GeoIP2
         public CityResponse City(string ipAddress)
         {
             return Execute<CityResponse>(ipAddress, "City");
+        }
+
+        /// <summary>
+        ///     Tries to lookup a <see cref="CityResponse" /> for the specified IP address.
+        /// </summary>
+        /// <param name="ipAddress">The IP address.</param>
+        /// <param name="response">The <see cref="CityResponse" />.</param>
+        /// <returns>A <see cref="bool" /> describing whether the IP address was found.</returns>
+        public bool TryCity(IPAddress ipAddress, out CityResponse response)
+        {
+            response = Execute<CityResponse>(ipAddress, "City", false);
+            return response != null;
+        }
+
+        /// <summary>
+        ///     Tries to lookup a <see cref="CityResponse" /> for the specified IP address.
+        /// </summary>
+        /// <param name="ipAddress">The IP address.</param>
+        /// <param name="response">The <see cref="CityResponse" />.</param>
+        /// <returns>A <see cref="bool" /> describing whether the IP address was found.</returns>
+        public bool TryCity(string ipAddress, out CityResponse response)
+        {
+            response = Execute<CityResponse>(ipAddress, "City", false);
+            return response != null;
         }
 
         /// <summary>

--- a/GeoIP2/DatabaseReader.cs
+++ b/GeoIP2/DatabaseReader.cs
@@ -176,20 +176,20 @@ namespace MaxMind.GeoIP2
             return Execute<IspResponse>(ipAddress, "GeoIP2-ISP");
         }
 
-        private T Execute<T>(string ipStr, string type) where T : AbstractResponse
+        private T Execute<T>(string ipStr, string type, bool throwOnNullResponse = true) where T : AbstractResponse
         {
             IPAddress ip = null;
             if (ipStr != null && !IPAddress.TryParse(ipStr, out ip))
                 throw new GeoIP2Exception($"The specified IP address was incorrectly formatted: {ipStr}");
-            return Execute<T>(ipStr, ip, type);
+            return Execute<T>(ipStr, ip, type, throwOnNullResponse);
         }
 
-        private T Execute<T>(IPAddress ipAddress, string type) where T : AbstractResponse
+        private T Execute<T>(IPAddress ipAddress, string type, bool throwOnNullResponse = true) where T : AbstractResponse
         {
-            return Execute<T>(ipAddress.ToString(), ipAddress, type);
+            return Execute<T>(ipAddress.ToString(), ipAddress, type, throwOnNullResponse);
         }
 
-        private T Execute<T>(string ipStr, IPAddress ipAddress, string type) where T : AbstractResponse
+        private T Execute<T>(string ipStr, IPAddress ipAddress, string type, bool throwOnNullResponse = true) where T : AbstractResponse
         {
             if (!Metadata.DatabaseType.Contains(type))
             {
@@ -203,7 +203,16 @@ namespace MaxMind.GeoIP2
             var response = _reader.Find<T>(ipAddress, injectables);
 
             if (response == null)
-                throw new AddressNotFoundException("The address " + ipStr + " is not in the database.");
+            {
+                if (throwOnNullResponse)
+                {
+                    throw new AddressNotFoundException("The address " + ipStr + " is not in the database.");
+                }
+                else
+                {
+                    return null;
+                }
+            }
 
             response.SetLocales(_locales);
 

--- a/GeoIP2/DatabaseReader.cs
+++ b/GeoIP2/DatabaseReader.cs
@@ -195,6 +195,18 @@ namespace MaxMind.GeoIP2
         }
 
         /// <summary>
+        ///     Tries to lookup an <see cref="AnonymousIPResponse" /> for the specified IP address.
+        /// </summary>
+        /// <param name="ipAddress">The IP address.</param>
+        /// <param name="response">The <see cref="AnonymousIPResponse" />.</param>
+        /// <returns>A <see cref="bool" /> describing whether the IP address was found.</returns>
+        public bool TryAnonymousIP(string ipAddress, out AnonymousIPResponse response)
+        {
+            response = Execute<AnonymousIPResponse>(ipAddress, "GeoIP2-Anonymous-IP", false);
+            return response != null;
+        }
+
+        /// <summary>
         ///     Returns an <see cref="ConnectionTypeResponse" /> for the specified IP address.
         /// </summary>
         /// <param name="ipAddress">The IP address.</param>
@@ -202,6 +214,18 @@ namespace MaxMind.GeoIP2
         public ConnectionTypeResponse ConnectionType(string ipAddress)
         {
             return Execute<ConnectionTypeResponse>(ipAddress, "GeoIP2-Connection-Type");
+        }
+
+        /// <summary>
+        ///     Tries to lookup a <see cref="ConnectionTypeResponse" /> for the specified IP address.
+        /// </summary>
+        /// <param name="ipAddress">The IP address.</param>
+        /// <param name="response">The <see cref="ConnectionTypeResponse" />.</param>
+        /// <returns>A <see cref="bool" /> describing whether the IP address was found.</returns>
+        public bool TryConnectionType(string ipAddress, out ConnectionTypeResponse response)
+        {
+            response = Execute<ConnectionTypeResponse>(ipAddress, "GeoIP2-Connection-Type", false);
+            return response != null;
         }
 
         /// <summary>
@@ -215,6 +239,18 @@ namespace MaxMind.GeoIP2
         }
 
         /// <summary>
+        ///     Tries to lookup a <see cref="DomainResponse" /> for the specified IP address.
+        /// </summary>
+        /// <param name="ipAddress">The IP address.</param>
+        /// <param name="response">The <see cref="DomainResponse" />.</param>
+        /// <returns>A <see cref="bool" /> describing whether the IP address was found.</returns>
+        public bool TryDomain(string ipAddress, out DomainResponse response)
+        {
+            response = Execute<DomainResponse>(ipAddress, "GeoIP2-Domain", false);
+            return response != null;
+        }
+
+        /// <summary>
         ///     Returns an <see cref="IspResponse" /> for the specified IP address.
         /// </summary>
         /// <param name="ipAddress">The IP address.</param>
@@ -222,6 +258,18 @@ namespace MaxMind.GeoIP2
         public IspResponse Isp(string ipAddress)
         {
             return Execute<IspResponse>(ipAddress, "GeoIP2-ISP");
+        }
+
+        /// <summary>
+        ///     Tries to lookup an <see cref="IspResponse" /> for the specified IP address.
+        /// </summary>
+        /// <param name="ipAddress">The IP address.</param>
+        /// <param name="response">The <see cref="IspResponse" />.</param>
+        /// <returns>A <see cref="bool" /> describing whether the IP address was found.</returns>
+        public bool TryIsp(string ipAddress, out IspResponse response)
+        {
+            response = Execute<IspResponse>(ipAddress, "GeoIP2-ISP", false);
+            return response != null;
         }
 
         private T Execute<T>(string ipStr, string type, bool throwOnNullResponse = true) where T : AbstractResponse


### PR DESCRIPTION
Refers to #31 

Added new `TryCity` and `TryCountry` methods that don't throw an exception when the IP address cannot be found. This avoids using exceptions for flow control.