### PR TITLE
NamedEntity.Name: create less objects

### DIFF
--- a/GeoIP2/Model/NamedEntity.cs
+++ b/GeoIP2/Model/NamedEntity.cs
@@ -69,8 +69,9 @@ namespace MaxMind.GeoIP2.Model
         {
             get
             {
-                var locale = Locales.FirstOrDefault(l => Names.ContainsKey(l));
-                return locale == null ? null : Names[locale];
+                var names = _names;
+                var locale = Locales.FirstOrDefault(l => names.ContainsKey(l));
+                return locale == null ? null : names[locale];
             }
         }
 


### PR DESCRIPTION
NamedEntity.Names returns a new dictionary, which is a good idea to avoid returning
something that would give the possibility to change the state of the instance.

On the other hand, we know that NamedEntity.Name isn't going to change the names,
there's hence no need to pay the price for this object creation. Price which is
actually quite high since it uses to create such a new Dictionary in a loop.

According to microbench (on .Net 4.0) it saves an order of magnitude.

Also: I use a local variable rather than referencing _names directly in Linq
to ensure we're thread safe