### PR TITLE
Add CI badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # GeoIP2 .NET API #
 
+[![Windows CI](https://ci.appveyor.com/api/projects/status/github/maxmind/GeoIP2-dotnet?svg=true)](https://ci.appveyor.com/project/maxmind/GeoIP2-dotnet/branch/master "Appveyor CI")
+[![Unix CI](https://travis-ci.org/maxmind/GeoIP2-dotnet.svg?branch=master)](https://travis-ci.org/maxmind/GeoIP2-dotnet "Travis CI")
+
 ## Description ##
 
 This distribution provides an API for the GeoIP2


### PR DESCRIPTION
Should these be added to MaxMind-DB-Reader-dotnet's README as well:

```markdown
[![Windows CI](https://ci.appveyor.com/api/projects/status/github/maxmind/MaxMind-DB-Reader-dotnet?svg=true)](https://ci.appveyor.com/project/maxmind/MaxMind-DB-Reader-dotnet/branch/master "Appveyor CI")
[![Unix CI](https://travis-ci.org/maxmind/MaxMind-DB-Reader-dotnet.svg?branch=master)](https://travis-ci.org/maxmind/MaxMind-DB-Reader-dotnet "Travis CI")
```