### PR TITLE
Allow Newtonsoft.Json 11

### DIFF
--- a/MaxMind.GeoIP2/MaxMind.GeoIP2.csproj
+++ b/MaxMind.GeoIP2/MaxMind.GeoIP2.csproj
@@ -30,7 +30,7 @@
   <ItemGroup>
     <PackageReference Include="MaxMind.Db" Version="2.3.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.4.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">


### PR DESCRIPTION
Currently the library has a version set on `10.0.3` for `Newtonsoft.Json`. I'd like to use newer version without having to add bindings.