### PR TITLE
Add Dockerfile + Makefile for running common tasks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM microsoft/dotnet:2.1-sdk
+
+ENV PATH="${PATH}:~/.dotnet/tools"
+
+RUN dotnet tool install --global dotnet-outdated
+
+WORKDIR /project

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+define update_project
+	docker run \
+		-it \
+		--rm \
+		-v $$(pwd)/$(1):/project \
+		geoip2-dotnet \
+		dotnet outdated -u
+endef
+
+build-image:
+	docker build -t geoip2-dotnet .
+
+update_dependencies: build-image
+	$(call update_project,MaxMind.GeoIP2)
+	$(call update_project,MaxMind.GeoIP2.Benchmark)
+	$(call update_project,MaxMind.GeoIP2.UnitTests)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
+CONFIGURATION ?= Release
+CONSOLE_FRAMEWORK ?= netcoreapp2.0
+DOTNETCORE ?= 1
+MAXMIND_BENCHMARK_DB = /project/MaxMind.GeoIP2.Benchmark/GeoLite2-City.mmdb
+
 define update_project
-	docker run \
+	@docker run \
 		-it \
 		--rm \
 		-v $$(pwd)/$(1):/project \
@@ -7,10 +12,38 @@ define update_project
 		dotnet outdated -u
 endef
 
+benchmark:
+	@docker run \
+		-it \
+		--rm \
+		-v $$(pwd)/$(1):/project \
+		-e "DOTNETCORE=$(DOTNETCORE)" \
+		-e "MAXMIND_BENCHMARK_DB=$(MAXMIND_BENCHMARK_DB)" \
+		geoip2-dotnet \
+		/bin/sh -c "dotnet run \
+			-c $(CONFIGURATION) \
+			-f $(CONSOLE_FRAMEWORK) \
+			-p ./MaxMind.GeoIP2.Benchmark/MaxMind.GeoIP2.Benchmark.csproj"
+
 build-image:
 	docker build -t geoip2-dotnet .
 
-update_dependencies: build-image
+init: build-image
+	git submodule update --init --recursive
+
+test:
+	@docker run \
+		-it \
+		--rm \
+		-v $$(pwd)/$(1):/project \
+		-e "DOTNETCORE=$(DOTNETCORE)" \
+		geoip2-dotnet \
+		/bin/sh -c "dotnet restore ./MaxMind.GeoIP2.sln && dotnet test \
+			-c $(CONFIGURATION) \
+			-f $(CONSOLE_FRAMEWORK) \
+			./MaxMind.GeoIP2.sln"
+
+update_dependencies:
 	$(call update_project,MaxMind.GeoIP2)
 	$(call update_project,MaxMind.GeoIP2.Benchmark)
 	$(call update_project,MaxMind.GeoIP2.UnitTests)

--- a/README.dev.md
+++ b/README.dev.md
@@ -1,9 +1,9 @@
-To run the unit tests on Linux:
+## Running Unit Tests on Linux
 
 1. Install dotnet core, cli, and sdk
 2. `MAXMIND_TEST_BASE_DIR="$PWD/GeoIP2.UnitTests" CONFIGURATION=Debug dev-bin`
 
-To publish the to NuGet:
+## Publishing to NuGet
 
 1. Review open issues and PRs to see if any can easily be fixed, closed, or
    merged.
@@ -15,3 +15,23 @@ To publish the to NuGet:
    NuGet, and make a GitHub release.
 5. Update GitHub Release page for the release.
 6. Verify the release on [NuGet](https://www.nuget.org/packages/MaxMind.GeoIP2/).
+
+## Using Docker
+
+A Dockerfile is included to build an image that can assist in updating dependencies, running benchmarks and running tests.
+
+A `Makefile` is also included to act as a task runner for the tasks mentioned above. Below are the targets and their descriptions.
+
+```Makefile
+# Initialize the repo by installing git submodules and building the `geoip2-dotnet` Docker image
+make init
+
+# Run benchmarks
+make benchmark
+
+# Run tests
+make test
+
+# Update dependencies
+make update_dependencies
+```


### PR DESCRIPTION
I've added a Dockerfile and Makefile that enables running benchmarks, running tests, and updating dependencies via a Docker container. The goal is to provide a basic, portable environment that a variety of developers can quickly get up and running.