### PR TITLE
Feature/httpclientfactory

### DIFF
--- a/MaxMind.GeoIP2.UnitTests/MaxMind.GeoIP2.UnitTests.csproj
+++ b/MaxMind.GeoIP2.UnitTests/MaxMind.GeoIP2.UnitTests.csproj
@@ -43,6 +43,18 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <PackageReference Include="Microsoft.Extensions.Options">
+      <Version>3.1.3</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <PackageReference Include="Microsoft.Extensions.Options">
+      <Version>3.1.3</Version>
+    </PackageReference>
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\MaxMind.GeoIP2\MaxMind.GeoIP2.csproj" />
   </ItemGroup>

--- a/MaxMind.GeoIP2.UnitTests/WebServiceClientTests.cs
+++ b/MaxMind.GeoIP2.UnitTests/WebServiceClientTests.cs
@@ -481,7 +481,7 @@ namespace MaxMind.GeoIP2.UnitTests
 
         #region NetCoreTests
 
-#if NETCOREAPP3_0 || NETCOREAPP2_1
+#if !NET452
 
         private static WebServiceClient CreateClientCore(string type, string ipAddress = "1.2.3.4",
             HttpStatusCode status = HttpStatusCode.OK, string? contentType = null, string content = "")

--- a/MaxMind.GeoIP2.UnitTests/WebServiceClientTests.cs
+++ b/MaxMind.GeoIP2.UnitTests/WebServiceClientTests.cs
@@ -7,7 +7,7 @@ using MaxMind.GeoIP2.Responses;
 #if !NETCOREAPP1_1
 using MaxMind.GeoIP2.UnitTests.Mock;
 #endif
-#if NETCOREAPP3_0 || NETCOREAPP2_1
+#if !NET452
 using Microsoft.Extensions.Options;
 #endif
 using RichardSzalay.MockHttp;

--- a/MaxMind.GeoIP2/Http/AsyncClient.cs
+++ b/MaxMind.GeoIP2/Http/AsyncClient.cs
@@ -18,7 +18,7 @@ namespace MaxMind.GeoIP2.Http
     {
         private readonly HttpClient _httpClient;
         private bool _disposed;
-        private readonly HttpMessageHandler _httpMessageHandler;
+        private readonly HttpMessageHandler? _httpMessageHandler;
 
 #if !NETSTANDARD1_4  // Issue https://github.com/dotnet/roslyn/issues/8505
         // As far as I can tell, this warning is a false positive. It is for the HttpClient instance.

--- a/MaxMind.GeoIP2/Http/AsyncClient.cs
+++ b/MaxMind.GeoIP2/Http/AsyncClient.cs
@@ -37,16 +37,7 @@ namespace MaxMind.GeoIP2.Http
                 _httpMessageHandler = httpMessageHandler ?? new HttpClientHandler();
                 try
                 {
-                    _httpClient = new HttpClient(_httpMessageHandler)
-                    {
-                        DefaultRequestHeaders =
-                    {
-                        Authorization = new AuthenticationHeaderValue("Basic", auth),
-                        Accept = {new MediaTypeWithQualityHeaderValue("application/json")},
-                        UserAgent = {userAgent}
-                    },
-                        Timeout = TimeSpan.FromMilliseconds(timeout)
-                    };
+                    _httpClient = new HttpClient(_httpMessageHandler);                    
                 }
                 catch
                 {
@@ -57,12 +48,13 @@ namespace MaxMind.GeoIP2.Http
             }
             else
             {
-                _httpClient = httpClient;
-                _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", auth);
-                _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                _httpClient.DefaultRequestHeaders.UserAgent.Add(userAgent);
-                _httpClient.Timeout = TimeSpan.FromMilliseconds(timeout);
+                _httpClient = httpClient;                
             }
+
+            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", auth);
+            _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            _httpClient.DefaultRequestHeaders.UserAgent.Add(userAgent);
+            _httpClient.Timeout = TimeSpan.FromMilliseconds(timeout);
         }
 
         public async Task<Response> Get(Uri uri)

--- a/MaxMind.GeoIP2/MaxMind.GeoIP2.csproj
+++ b/MaxMind.GeoIP2/MaxMind.GeoIP2.csproj
@@ -53,4 +53,16 @@
     <PackageReference Include="System.Threading" Version="4.3.0" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Extensions.Options">
+      <Version>3.1.3</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="Microsoft.Extensions.Options">
+      <Version>3.1.3</Version>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/MaxMind.GeoIP2/WebServiceClient.cs
+++ b/MaxMind.GeoIP2/WebServiceClient.cs
@@ -89,7 +89,7 @@ namespace MaxMind.GeoIP2
 
         private static ProductInfoHeaderValue UserAgent => new ProductInfoHeaderValue("GeoIP2-dotnet", Version);
 
-#if NETSTANDARD2_0 || NETSTANDARD2_1
+#if !NET45 && !NETSTANDARD1_4
         /// <summary>
         ///     Initializes a new instance of the <see cref="WebServiceClient" /> class.
         /// </summary>

--- a/MaxMind.GeoIP2/WebServiceClient.cs
+++ b/MaxMind.GeoIP2/WebServiceClient.cs
@@ -15,6 +15,10 @@ using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 
+#if NETSTANDARD2_0 || NETSTANDARD2_1
+using Microsoft.Extensions.Options;
+#endif
+
 #endregion
 
 namespace MaxMind.GeoIP2
@@ -85,6 +89,29 @@ namespace MaxMind.GeoIP2
 
         private static ProductInfoHeaderValue UserAgent => new ProductInfoHeaderValue("GeoIP2-dotnet", Version);
 
+#if NETSTANDARD2_0 || NETSTANDARD2_1
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="WebServiceClient" /> class.
+        /// </summary>
+        /// <param name="httpClient">Injected HttpClient.</param>
+        /// <param name="options">Injected Options.</param>
+        public WebServiceClient(
+            HttpClient httpClient, 
+            IOptionsMonitor<WebServiceClientOptions> options
+        ) : this(
+            options.CurrentValue.AccountId, 
+            options.CurrentValue.LicenseKey, 
+            options.CurrentValue.Locales, 
+            options.CurrentValue.Host, 
+            options.CurrentValue.Timeout,
+            null,
+            false,
+            null,
+            httpClient)
+        {
+        }
+#endif
+
         /// <summary>
         ///     Initializes a new instance of the <see cref="WebServiceClient" /> class.
         /// </summary>
@@ -132,6 +159,7 @@ namespace MaxMind.GeoIP2
 #if !NETSTANDARD1_4
             , ISyncClient? syncWebRequest = null
 #endif
+            , HttpClient? httpClient = null
             )
         {
             var auth = EncodedAuth(accountId, licenseKey);
@@ -139,8 +167,8 @@ namespace MaxMind.GeoIP2
             _locales = locales == null ? new List<string> { "en" } : new List<string>(locales);
 #if !NETSTANDARD1_4
             _syncClient = syncWebRequest ?? new SyncClient(auth, timeout, UserAgent);
-#endif
-            _asyncClient = new AsyncClient(auth, timeout, UserAgent, httpMessageHandler);
+#endif            
+            _asyncClient = new AsyncClient(auth, timeout, UserAgent, httpMessageHandler, httpClient);
         }
 
         /// <summary>

--- a/MaxMind.GeoIP2/WebServiceClient.cs
+++ b/MaxMind.GeoIP2/WebServiceClient.cs
@@ -15,7 +15,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 
-#if NETSTANDARD2_0 || NETSTANDARD2_1
+#if !NET45 && !NETSTANDARD1_4
 using Microsoft.Extensions.Options;
 #endif
 
@@ -95,6 +95,7 @@ namespace MaxMind.GeoIP2
         /// </summary>
         /// <param name="httpClient">Injected HttpClient.</param>
         /// <param name="options">Injected Options.</param>
+        [CLSCompliant(false)]
         public WebServiceClient(
             HttpClient httpClient, 
             IOptions<WebServiceClientOptions> options

--- a/MaxMind.GeoIP2/WebServiceClient.cs
+++ b/MaxMind.GeoIP2/WebServiceClient.cs
@@ -97,13 +97,13 @@ namespace MaxMind.GeoIP2
         /// <param name="options">Injected Options.</param>
         public WebServiceClient(
             HttpClient httpClient, 
-            IOptionsMonitor<WebServiceClientOptions> options
+            IOptions<WebServiceClientOptions> options
         ) : this(
-            options.CurrentValue.AccountId, 
-            options.CurrentValue.LicenseKey, 
-            options.CurrentValue.Locales, 
-            options.CurrentValue.Host, 
-            options.CurrentValue.Timeout,
+            options.Value.AccountId, 
+            options.Value.LicenseKey, 
+            options.Value.Locales, 
+            options.Value.Host, 
+            options.Value.Timeout,
             null,
             false,
             null,

--- a/MaxMind.GeoIP2/WebServiceClientOptions.cs
+++ b/MaxMind.GeoIP2/WebServiceClientOptions.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MaxMind.GeoIP2
+{
+    /// <summary>
+    /// Options class for WebServiceClient.
+    /// </summary>
+    public class WebServiceClientOptions
+    {
+        /// <summary>
+        /// Your MaxMind account ID.
+        /// </summary>
+        public int AccountId { get; set; }
+
+        /// <summary>
+        /// Your MaxMind license key.
+        /// </summary>
+        public string LicenseKey { get; set; } = string.Empty;
+
+        /// <summary>
+        /// List of locale codes to use in name property from most preferred to least preferred.
+        /// </summary>
+        public IEnumerable<string>? Locales { get; set; }
+
+        /// <summary>
+        /// Timeout in milliseconds for connection to web service. The default is 3000.
+        /// </summary>
+        public int Timeout { get; set; } = 3000;
+
+        /// <summary>
+        /// The host to use when accessing the service.
+        /// </summary>
+        public string Host { get; set; } = "geoip.maxmind.com";
+    }
+}

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ services.AddHttpClient<WebServiceClient>(); // Configure dependency injection fo
 
 2. Add configuration in your ```appsettings.json``` with your account ID and license key.
 
-```json
+```jsonc
 ...
   "MaxMind": {
     "AccountId": 123456,

--- a/README.md
+++ b/README.md
@@ -63,6 +63,56 @@ each of which represents part of the data returned by the web service.
 
 See the API documentation for more details.
 
+### ASP.NET Core Usage ###
+
+To use the web service API with HttpClient factory pattern as a [Typed client](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/http-requests?view=aspnetcore-3.1#typed-clients)
+you need to do the following:
+
+1. Add the following lines to ```Startup.cs``` ```ConfigureServices``` method:
+
+```csharp
+services.Configure<WebServiceClientOptions>(Configuration.GetSection("MaxMind")); // Configure to read configuration options from MaxMind section
+
+services.AddHttpClient<WebServiceClient>(); // Configure dependency injection for WebServiceClient
+```
+
+2. Add configuration in your ```appsettings.json``` with your account ID and license key.
+
+```json
+...
+  "MaxMind": {
+    "AccountId": 123456,
+    "LicenseKey": "1234567890",
+    "Timeout": 3000, // optional
+    "Host": "geoip.maxmind.com" // optional
+  },
+...
+```
+
+3. Inject the ```WebServiceClient``` where you need to make the call and use it.
+
+```csharp
+[ApiController]
+[Route("[controller]")]
+public class MaxMindController : ControllerBase
+{
+    private readonly WebServiceClient _maxMindClient;
+
+    public MaxMindController(WebServiceClient maxMindClient)
+    {
+        _maxMindClient = maxMindClient;
+    }
+
+    [HttpGet]
+    public async Task<string> Get()
+    {
+        var location = await _maxMindClient.CountryAsync();
+
+        return location.Country.Name;
+    }
+}
+```
+
 ## Web Service Example ##
 
 ### Country Service (Sync) ###

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ See the API documentation for more details.
 To use the web service API with HttpClient factory pattern as a [Typed client](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/http-requests?view=aspnetcore-3.1#typed-clients)
 you need to do the following:
 
-1. Add the following lines to ```Startup.cs``` ```ConfigureServices``` method:
+1. Add the following lines to `Startup.cs` `ConfigureServices` method:
 
 ```csharp
 services.Configure<WebServiceClientOptions>(Configuration.GetSection("MaxMind")); // Configure to read configuration options from MaxMind section
@@ -76,7 +76,7 @@ services.Configure<WebServiceClientOptions>(Configuration.GetSection("MaxMind"))
 services.AddHttpClient<WebServiceClient>(); // Configure dependency injection for WebServiceClient
 ```
 
-2. Add configuration in your ```appsettings.json``` with your account ID and license key.
+2. Add configuration in your `appsettings.json` with your account ID and license key.
 
 ```jsonc
 ...
@@ -89,7 +89,7 @@ services.AddHttpClient<WebServiceClient>(); // Configure dependency injection fo
 ...
 ```
 
-3. Inject the ```WebServiceClient``` where you need to make the call and use it.
+3. Inject the `WebServiceClient` where you need to make the call and use it.
 
 ```csharp
 [ApiController]


### PR DESCRIPTION
This PR includes adding an option to create ```WebServiceClient``` as Typed client with ```IHttpClientFactory``` in .NET Core 2.1+.

This requires ```WebServiceClientOptions``` to be setup at startup via Options pattern.

Unit tests are created to test all works OK, for both sync and async methods.

Haven't provided changes to Readme.md or release notes as I am not sure how to do it. I can provide with some samples for setup and DI in Controller or some sample project.