### PR TITLE
Use 'GeoIP'/'GeoLite' branding in documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,8 @@ code in this repository.
 
 **GeoIP2-dotnet** is MaxMind's official .NET client library for:
 
-- **GeoIP2/GeoLite2 Web Services**: Country, City, and Insights endpoints
-- **GeoIP2/GeoLite2 Databases**: Local MMDB file reading for various database
+- **GeoIP/GeoLite Web Services**: Country, City Plus, and Insights endpoints
+- **GeoIP/GeoLite Databases**: Local MMDB file reading for various database
   types (City, Country, ASN, Anonymous IP, Anonymous Plus, ISP, etc.)
 
 The library provides both web service clients and database readers that return
@@ -210,8 +210,8 @@ Always update `releasenotes.md` for user-facing changes:
 ## Additional Resources
 
 - [API Documentation](https://maxmind.github.io/GeoIP2-dotnet/)
-- [GeoIP2 Web Services Docs](https://dev.maxmind.com/geoip/docs/web-services?lang=en)
-- [GeoIP2 Database Docs](https://dev.maxmind.com/geoip/docs/databases?lang=en)
+- [GeoIP Web Services Docs](https://dev.maxmind.com/geoip/docs/web-services?lang=en)
+- [GeoIP Database Docs](https://dev.maxmind.com/geoip/docs/databases?lang=en)
 - [MaxMind DB Format](https://maxmind.github.io/MaxMind-DB/)
 - GitHub Issues: https://github.com/maxmind/GeoIP2-dotnet/issues
 

--- a/MaxMind.GeoIP2.Benchmark/MaxMind.GeoIP2.Benchmark.csproj
+++ b/MaxMind.GeoIP2.Benchmark/MaxMind.GeoIP2.Benchmark.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>Benchmark project to validate MaxMind GeoIP2 Database Reader and Web Service Client</Description>
+    <Description>Benchmark project to validate MaxMind GeoIP Database Reader and Web Service Client</Description>
     <VersionPrefix>5.0.0</VersionPrefix>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net10.0;net9.0;net8.0;net481</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">net10.0;net9.0;net8.0</TargetFrameworks>

--- a/MaxMind.GeoIP2.UnitTests/MaxMind.GeoIP2.UnitTests.csproj
+++ b/MaxMind.GeoIP2.UnitTests/MaxMind.GeoIP2.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>Test project to validate MaxMind GeoIP2 Database Reader and Web Service Client</Description>
+    <Description>Test project to validate MaxMind GeoIP Database Reader and Web Service Client</Description>
     <VersionPrefix>5.0.0</VersionPrefix>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net10.0;net9.0;net8.0;net481</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">net10.0;net9.0;net8.0</TargetFrameworks>

--- a/MaxMind.GeoIP2/DatabaseReader.cs
+++ b/MaxMind.GeoIP2/DatabaseReader.cs
@@ -15,7 +15,7 @@ using System.Net;
 namespace MaxMind.GeoIP2
 {
     /// <summary>
-    ///     Instances of this class provide a reader for the GeoIP2 database format
+    ///     Instances of this class provide a reader for the GeoIP database format
     /// </summary>
     public class DatabaseReader : IGeoIP2DatabaseReader, IDisposable
     {
@@ -182,7 +182,7 @@ namespace MaxMind.GeoIP2
         }
 
         /// <summary>
-        ///     Look up an IP address in a GeoIP2 Anonymous IP.
+        ///     Look up an IP address in a GeoIP Anonymous IP.
         /// </summary>
         /// <param name="ipAddress">The IP address.</param>
         /// <returns>An <see cref="AnonymousIPResponse" /></returns>
@@ -192,7 +192,7 @@ namespace MaxMind.GeoIP2
         }
 
         /// <summary>
-        ///     Look up an IP address in a GeoIP2 Anonymous IP.
+        ///     Look up an IP address in a GeoIP Anonymous IP.
         /// </summary>
         /// <param name="ipAddress">The IP address.</param>
         /// <returns>An <see cref="AnonymousIPResponse" /></returns>

--- a/MaxMind.GeoIP2/DatabaseReader.cs
+++ b/MaxMind.GeoIP2/DatabaseReader.cs
@@ -182,7 +182,7 @@ namespace MaxMind.GeoIP2
         }
 
         /// <summary>
-        ///     Look up an IP address in a GeoIP Anonymous IP.
+        ///     Look up an IP address in a GeoIP Anonymous IP database.
         /// </summary>
         /// <param name="ipAddress">The IP address.</param>
         /// <returns>An <see cref="AnonymousIPResponse" /></returns>
@@ -192,7 +192,7 @@ namespace MaxMind.GeoIP2
         }
 
         /// <summary>
-        ///     Look up an IP address in a GeoIP Anonymous IP.
+        ///     Look up an IP address in a GeoIP Anonymous IP database.
         /// </summary>
         /// <param name="ipAddress">The IP address.</param>
         /// <returns>An <see cref="AnonymousIPResponse" /></returns>
@@ -224,7 +224,7 @@ namespace MaxMind.GeoIP2
         }
 
         /// <summary>
-        ///     Look up an IP address in a GeoIP Anonymous Plus.
+        ///     Look up an IP address in a GeoIP Anonymous Plus database.
         /// </summary>
         /// <param name="ipAddress">The IP address.</param>
         /// <returns>An <see cref="AnonymousPlusResponse" /></returns>
@@ -234,7 +234,7 @@ namespace MaxMind.GeoIP2
         }
 
         /// <summary>
-        ///     Look up an IP address in a GeoIP Anonymous Plus.
+        ///     Look up an IP address in a GeoIP Anonymous Plus database.
         /// </summary>
         /// <param name="ipAddress">The IP address.</param>
         /// <returns>An <see cref="AnonymousPlusResponse" /></returns>

--- a/MaxMind.GeoIP2/Exceptions/GeoIP2Exception.cs
+++ b/MaxMind.GeoIP2/Exceptions/GeoIP2Exception.cs
@@ -7,8 +7,8 @@ using System.Runtime.Serialization;
 namespace MaxMind.GeoIP2.Exceptions
 {
     /// <summary>
-    ///     This class represents a generic GeoIP2 error. All other exceptions thrown by
-    ///     the GeoIP2 API subclass this exception
+    ///     This class represents a generic GeoIP error. All other exceptions thrown by
+    ///     the GeoIP API subclass this exception
     /// </summary>
     [Serializable]
     public class GeoIP2Exception : Exception

--- a/MaxMind.GeoIP2/Exceptions/InvalidRequestException.cs
+++ b/MaxMind.GeoIP2/Exceptions/InvalidRequestException.cs
@@ -8,7 +8,7 @@ using System.Runtime.Serialization;
 namespace MaxMind.GeoIP2.Exceptions
 {
     /// <summary>
-    ///     This class represents a non-specific error returned by MaxMind's GeoIP2 web
+    ///     This class represents a non-specific error returned by MaxMind's GeoIP web
     ///     service. This occurs when the web service is up and responding to requests,
     ///     but the request sent was invalid in some way.
     /// </summary>

--- a/MaxMind.GeoIP2/IGeoIP2DatabaseReader.cs
+++ b/MaxMind.GeoIP2/IGeoIP2DatabaseReader.cs
@@ -21,14 +21,14 @@ namespace MaxMind.GeoIP2
         Metadata Metadata { get; }
 
         /// <summary>
-        ///     Look up an IP address in a GeoIP Anonymous IP.
+        ///     Look up an IP address in a GeoIP Anonymous IP database.
         /// </summary>
         /// <param name="ipAddress">The IP address.</param>
         /// <returns>An <see cref="AnonymousIPResponse" /></returns>
         AnonymousIPResponse AnonymousIP(IPAddress ipAddress);
 
         /// <summary>
-        ///     Look up an IP address in a GeoIP Anonymous IP.
+        ///     Look up an IP address in a GeoIP Anonymous IP database.
         /// </summary>
         /// <param name="ipAddress">The IP address.</param>
         /// <returns>An <see cref="AnonymousIPResponse" /></returns>
@@ -51,14 +51,14 @@ namespace MaxMind.GeoIP2
         bool TryAnonymousIP(string ipAddress, [MaybeNullWhen(false)] out AnonymousIPResponse response);
 
         /// <summary>
-        ///     Look up an IP address in a GeoIP Anonymous Plus.
+        ///     Look up an IP address in a GeoIP Anonymous Plus database.
         /// </summary>
         /// <param name="ipAddress">The IP address.</param>
         /// <returns>An <see cref="AnonymousPlusResponse" /></returns>
         AnonymousPlusResponse AnonymousPlus(IPAddress ipAddress);
 
         /// <summary>
-        ///     Look up an IP address in a GeoIP Anonymous Plus.
+        ///     Look up an IP address in a GeoIP Anonymous Plus database.
         /// </summary>
         /// <param name="ipAddress">The IP address.</param>
         /// <returns>An <see cref="AnonymousPlusResponse" /></returns>

--- a/MaxMind.GeoIP2/IGeoIP2DatabaseReader.cs
+++ b/MaxMind.GeoIP2/IGeoIP2DatabaseReader.cs
@@ -21,14 +21,14 @@ namespace MaxMind.GeoIP2
         Metadata Metadata { get; }
 
         /// <summary>
-        ///     Look up an IP address in a GeoIP2 Anonymous IP.
+        ///     Look up an IP address in a GeoIP Anonymous IP.
         /// </summary>
         /// <param name="ipAddress">The IP address.</param>
         /// <returns>An <see cref="AnonymousIPResponse" /></returns>
         AnonymousIPResponse AnonymousIP(IPAddress ipAddress);
 
         /// <summary>
-        ///     Look up an IP address in a GeoIP2 Anonymous IP.
+        ///     Look up an IP address in a GeoIP Anonymous IP.
         /// </summary>
         /// <param name="ipAddress">The IP address.</param>
         /// <returns>An <see cref="AnonymousIPResponse" /></returns>

--- a/MaxMind.GeoIP2/IGeoIP2WebServicesClient.cs
+++ b/MaxMind.GeoIP2/IGeoIP2WebServicesClient.cs
@@ -46,61 +46,61 @@ namespace MaxMind.GeoIP2
         InsightsResponse Insights();
 
         /// <summary>
-        ///     Asynchronously query the GeoIP2 Country web service for the specified IP address.
+        ///     Asynchronously query the GeoIP Country web service for the specified IP address.
         /// </summary>
         /// <param name="ipAddress">The IP address.</param>
         /// <returns>Task that produces an object modeling the Country response</returns>
         Task<CountryResponse> CountryAsync(string ipAddress);
 
         /// <summary>
-        ///     Asynchronously query the GeoIP2 Country web service for the specified IP address.
+        ///     Asynchronously query the GeoIP Country web service for the specified IP address.
         /// </summary>
         /// <param name="ipAddress">The IP address.</param>
         /// <returns>Task that produces an object modeling the Country response</returns>
         Task<CountryResponse> CountryAsync(IPAddress ipAddress);
 
         /// <summary>
-        ///     Asynchronously query the GeoIP2 Country web service for the requesting IP address.
+        ///     Asynchronously query the GeoIP Country web service for the requesting IP address.
         /// </summary>
         /// <returns>Task that produces an object modeling the Country response</returns>
         Task<CountryResponse> CountryAsync();
 
         /// <summary>
-        ///     Asynchronously query the GeoIP2 City Plus web service for the specified IP address.
+        ///     Asynchronously query the GeoIP City Plus web service for the specified IP address.
         /// </summary>
         /// <param name="ipAddress">The IP address.</param>
         /// <returns>Task that produces an object modeling the City Plus response</returns>
         Task<CityResponse> CityAsync(string ipAddress);
 
         /// <summary>
-        ///     Asynchronously query the GeoIP2 City Plus web service for the specified IP address.
+        ///     Asynchronously query the GeoIP City Plus web service for the specified IP address.
         /// </summary>
         /// <param name="ipAddress">The IP address.</param>
         /// <returns>Task that produces an object modeling the City Plus response</returns>
         Task<CityResponse> CityAsync(IPAddress ipAddress);
 
         /// <summary>
-        ///     Asynchronously query the GeoIP2 City Plus web service for the requesting IP address.
+        ///     Asynchronously query the GeoIP City Plus web service for the requesting IP address.
         /// </summary>
         /// <returns>Task that produces an object modeling the City Plus response</returns>
         Task<CityResponse> CityAsync();
 
         /// <summary>
-        ///     Asynchronously query the GeoIP2 Insights web service for the specified IP address.
+        ///     Asynchronously query the GeoIP Insights web service for the specified IP address.
         /// </summary>
         /// <param name="ipAddress">The IP address.</param>
         /// <returns>Task that produces an object modeling the Insights response</returns>
         Task<InsightsResponse> InsightsAsync(string ipAddress);
 
         /// <summary>
-        ///     Asynchronously query the GeoIP2 Insights web service for the specified IP address.
+        ///     Asynchronously query the GeoIP Insights web service for the specified IP address.
         /// </summary>
         /// <param name="ipAddress">The IP address.</param>
         /// <returns>Task that produces an object modeling the Insights response</returns>
         Task<InsightsResponse> InsightsAsync(IPAddress ipAddress);
 
         /// <summary>
-        ///     Asynchronously query the GeoIP2 Insights web service for the requesting IP address.
+        ///     Asynchronously query the GeoIP Insights web service for the requesting IP address.
         /// </summary>
         /// <returns>Task that produces an object modeling the Insights response</returns>
         Task<InsightsResponse> InsightsAsync();

--- a/MaxMind.GeoIP2/MaxMind.GeoIP2.csproj
+++ b/MaxMind.GeoIP2/MaxMind.GeoIP2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>MaxMind GeoIP2 Database Reader and Web Service Client</Description>
+    <Description>MaxMind GeoIP Database Reader and Web Service Client</Description>
     <VersionPrefix>6.0.0</VersionPrefix>
     <TargetFrameworks>net10.0;net9.0;net8.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/MaxMind.GeoIP2/Model/Anonymizer.cs
+++ b/MaxMind.GeoIP2/Model/Anonymizer.cs
@@ -5,14 +5,14 @@ namespace MaxMind.GeoIP2.Model
 {
     /// <summary>
     ///     Contains anonymizer-related data associated with an IP address.
-    ///     This data is available from the GeoIP2 Insights web service.
+    ///     This data is available from the GeoIP Insights web service.
     /// </summary>
     public record Anonymizer
     {
         /// <summary>
         ///     A score ranging from 1 to 99 that represents our percent confidence
         ///     that the network is currently part of an actively used VPN service.
-        ///     This is available from the GeoIP2 Insights web service.
+        ///     This is available from the GeoIP Insights web service.
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("confidence")]
@@ -20,7 +20,7 @@ namespace MaxMind.GeoIP2.Model
 
         /// <summary>
         ///     This is true if the IP address belongs to any sort of anonymous
-        ///     network. This is available from the GeoIP2 Insights web service.
+        ///     network. This is available from the GeoIP Insights web service.
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("is_anonymous")]
@@ -28,7 +28,7 @@ namespace MaxMind.GeoIP2.Model
 
         /// <summary>
         ///     This is true if the IP address is registered to an anonymous
-        ///     VPN provider. This is available from the GeoIP2 Insights web
+        ///     VPN provider. This is available from the GeoIP Insights web
         ///     service.
         /// </summary>
         /// <remarks>
@@ -43,7 +43,7 @@ namespace MaxMind.GeoIP2.Model
         /// <summary>
         ///     This is true if the IP address belongs to a hosting or VPN
         ///     provider (see description of IsAnonymousVpn property).
-        ///     This is available from the GeoIP2 Insights web service.
+        ///     This is available from the GeoIP Insights web service.
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("is_hosting_provider")]
@@ -51,7 +51,7 @@ namespace MaxMind.GeoIP2.Model
 
         /// <summary>
         ///     This is true if the IP address belongs to a public proxy.
-        ///     This is available from the GeoIP2 Insights web service.
+        ///     This is available from the GeoIP Insights web service.
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("is_public_proxy")]
@@ -60,7 +60,7 @@ namespace MaxMind.GeoIP2.Model
         /// <summary>
         ///     This is true if the IP address is on a suspected anonymizing
         ///     network and belongs to a residential ISP. This is available
-        ///     from the GeoIP2 Insights web service.
+        ///     from the GeoIP Insights web service.
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("is_residential_proxy")]
@@ -68,7 +68,7 @@ namespace MaxMind.GeoIP2.Model
 
         /// <summary>
         ///     This is true if the IP address belongs to a Tor exit node.
-        ///     This is available from the GeoIP2 Insights web service.
+        ///     This is available from the GeoIP Insights web service.
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("is_tor_exit_node")]
@@ -77,7 +77,7 @@ namespace MaxMind.GeoIP2.Model
 #if NET6_0_OR_GREATER
         /// <summary>
         ///     The last day that the network was sighted in our analysis of
-        ///     anonymized networks. This is available from the GeoIP2 Insights
+        ///     anonymized networks. This is available from the GeoIP Insights
         ///     web service.
         /// </summary>
         [JsonInclude]
@@ -88,7 +88,7 @@ namespace MaxMind.GeoIP2.Model
         /// <summary>
         ///     The name of the VPN provider (e.g., NordVPN, SurfShark)
         ///     associated with the network. This is available from the
-        ///     GeoIP2 Insights web service.
+        ///     GeoIP Insights web service.
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("provider_name")]

--- a/MaxMind.GeoIP2/Model/Traits.cs
+++ b/MaxMind.GeoIP2/Model/Traits.cs
@@ -80,7 +80,7 @@ namespace MaxMind.GeoIP2.Model
         ///     IP risk score provided in minFraud and is not responsive to traffic on
         ///     your network. If you need realtime IP risk scoring based on behavioral
         ///     signals on your own network, please use minFraud. This is available
-        ///     from the GeoIP2 Insights web service.
+        ///     from the GeoIP Insights web service.
         ///     <para>
         ///     We do not provide an IP risk snapshot for low-risk networks. If this
         ///     field is not populated, we either do not have signals for the network
@@ -96,7 +96,7 @@ namespace MaxMind.GeoIP2.Model
 
         /// <summary>
         ///     This is true if the IP address belongs to any sort of anonymous
-        ///     network. This value is only available from the GeoIP2 Insights
+        ///     network. This value is only available from the GeoIP Insights
         ///     web service.
         /// </summary>
         [Obsolete("Please use the Anonymizer object on the response instead.")]
@@ -110,7 +110,7 @@ namespace MaxMind.GeoIP2.Model
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("is_anonymous_proxy")]
-        [Obsolete("Use our GeoIP2 Anonymous IP database instead.")]
+        [Obsolete("Use our GeoIP Anonymous IP database instead.")]
         [MapKey("is_anonymous_proxy")]
         public bool IsAnonymousProxy { get; init; }
 
@@ -127,7 +127,7 @@ namespace MaxMind.GeoIP2.Model
         /// <summary>
         ///     This is true if the IP address is registered to an anonymous
         ///     VPN provider.
-        ///     This value is only available from the GeoIP2 Insights web
+        ///     This value is only available from the GeoIP Insights web
         ///     service.
         /// </summary>
         /// <remarks>
@@ -144,7 +144,7 @@ namespace MaxMind.GeoIP2.Model
         /// <summary>
         ///     This is true if the IP address belongs to a hosting or VPN
         ///     provider (see description of IsAnonymousVpn property).
-        ///     This value is only available from the GeoIP2 Insights web
+        ///     This value is only available from the GeoIP Insights web
         ///     service.
         /// </summary>
         [Obsolete("Please use the Anonymizer object on the response instead.")]
@@ -156,7 +156,7 @@ namespace MaxMind.GeoIP2.Model
         /// <summary>
         ///     True if MaxMind believes this IP address to be a legitimate
         ///     proxy, such as an internal VPN used by a corporation. This is
-        ///     only available in the GeoIP2 Enterprise database.
+        ///     only available in the GeoIP Enterprise database.
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("is_legitimate_proxy")]
@@ -165,7 +165,7 @@ namespace MaxMind.GeoIP2.Model
 
         /// <summary>
         ///     This is true if the IP address belongs to a public proxy.
-        ///     This value is only available from the GeoIP2 Insights web
+        ///     This value is only available from the GeoIP Insights web
         ///     service.
         /// </summary>
         [Obsolete("Please use the Anonymizer object on the response instead.")]
@@ -177,7 +177,7 @@ namespace MaxMind.GeoIP2.Model
         /// <summary>
         ///     This is true if the IP address is on a suspected anonymizing
         ///     network and belongs to a residential ISP. This value is
-        ///     only available from the GeoIP2 Insights web service.
+        ///     only available from the GeoIP Insights web service.
         /// </summary>
         [Obsolete("Please use the Anonymizer object on the response instead.")]
         [JsonInclude]
@@ -196,7 +196,7 @@ namespace MaxMind.GeoIP2.Model
 
         /// <summary>
         ///     This is true if the IP address belongs to a Tor exit node.
-        ///     This value is only available from the GeoIP2 Insights web
+        ///     This value is only available from the GeoIP Insights web
         ///     service.
         /// </summary>
         [Obsolete("Please use the Anonymizer object on the response instead.")]
@@ -219,7 +219,7 @@ namespace MaxMind.GeoIP2.Model
         ///     The <a href="https://en.wikipedia.org/wiki/Mobile_country_code">
         ///     mobile country code (MCC)</a> associated with the IP address and ISP.
         ///     This value is available from the City Plus and Insights web services
-        ///     and the GeoIP2 Enterprise database.
+        ///     and the GeoIP Enterprise database.
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("mobile_country_code")]
@@ -230,7 +230,7 @@ namespace MaxMind.GeoIP2.Model
         ///     The <a href="https://en.wikipedia.org/wiki/Mobile_country_code">
         ///     mobile network code (MNC)</a> associated with the IP address and ISP.
         ///     This value is available from the City Plus and Insights web services
-        ///     and the GeoIP2 Enterprise database.
+        ///     and the GeoIP Enterprise database.
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("mobile_network_code")]
@@ -277,7 +277,7 @@ namespace MaxMind.GeoIP2.Model
         ///     The estimated number of users sharing the IP/network during the past
         ///     24 hours. For IPv4, the count is for the individual IP. For IPv6, the
         ///     count is for the /64 network. This value is only available from
-        ///     the GeoIP2 Insights web service.
+        ///     the GeoIP Insights web service.
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("user_count")]

--- a/MaxMind.GeoIP2/Properties/AssemblyInfo.cs
+++ b/MaxMind.GeoIP2/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 
 [assembly: AssemblyTitle("MaxMind.GeoIP2")]
-[assembly: AssemblyDescription("MaxMind GeoIP2 Database Reader and Web Service Client")]
+[assembly: AssemblyDescription("MaxMind GeoIP Database Reader and Web Service Client")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("MaxMind, Inc.")]
 [assembly: AssemblyProduct("MaxMind.GeoIP2")]

--- a/MaxMind.GeoIP2/Responses/AnonymousIPResponse.cs
+++ b/MaxMind.GeoIP2/Responses/AnonymousIPResponse.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 namespace MaxMind.GeoIP2.Responses
 {
     /// <summary>
-    ///     This record represents the GeoIP2 Anonymous IP response.
+    ///     This record represents the GeoIP Anonymous IP response.
     /// </summary>
     public record AnonymousIPResponse : AbstractResponse
     {

--- a/MaxMind.GeoIP2/Responses/AsnResponse.cs
+++ b/MaxMind.GeoIP2/Responses/AsnResponse.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 namespace MaxMind.GeoIP2.Responses
 {
     /// <summary>
-    ///     This record represents the GeoLite2 ASN response.
+    ///     This record represents the GeoLite ASN response.
     /// </summary>
     public record AsnResponse : AbstractResponse
     {

--- a/MaxMind.GeoIP2/Responses/CityResponse.cs
+++ b/MaxMind.GeoIP2/Responses/CityResponse.cs
@@ -1,8 +1,8 @@
 namespace MaxMind.GeoIP2.Responses
 {
     /// <summary>
-    ///     This record provides a model for data returned from the GeoIP2 City
-    ///     database and the GeoIP2 City Plus web services.
+    ///     This record provides a model for data returned from the GeoIP City
+    ///     database and the GeoIP City Plus web services.
     /// </summary>
     public record CityResponse : AbstractCityResponse
     {

--- a/MaxMind.GeoIP2/Responses/ConnectionTypeResponse.cs
+++ b/MaxMind.GeoIP2/Responses/ConnectionTypeResponse.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 namespace MaxMind.GeoIP2.Responses
 {
     /// <summary>
-    ///     This record represents the GeoIP2 Connection-Type response.
+    ///     This record represents the GeoIP Connection-Type response.
     /// </summary>
     public record ConnectionTypeResponse : AbstractResponse
     {

--- a/MaxMind.GeoIP2/Responses/CountryResponse.cs
+++ b/MaxMind.GeoIP2/Responses/CountryResponse.cs
@@ -1,8 +1,8 @@
 namespace MaxMind.GeoIP2.Responses
 {
     /// <summary>
-    ///     This record provides a model for the data returned from the GeoIP2
-    ///     Country database and the GeoIP2 Country web service.
+    ///     This record provides a model for the data returned from the GeoIP
+    ///     Country database and the GeoIP Country web service.
     /// </summary>
     public record CountryResponse : AbstractCountryResponse
     {

--- a/MaxMind.GeoIP2/Responses/DomainResponse.cs
+++ b/MaxMind.GeoIP2/Responses/DomainResponse.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 namespace MaxMind.GeoIP2.Responses
 {
     /// <summary>
-    ///     This record represents the GeoIP2 Domain response.
+    ///     This record represents the GeoIP Domain response.
     /// </summary>
     public record DomainResponse : AbstractResponse
     {

--- a/MaxMind.GeoIP2/Responses/EnterpriseResponse.cs
+++ b/MaxMind.GeoIP2/Responses/EnterpriseResponse.cs
@@ -1,7 +1,7 @@
 namespace MaxMind.GeoIP2.Responses
 {
     /// <summary>
-    ///     This record provides a model for the data returned by the GeoIP2 Enterprise
+    ///     This record provides a model for the data returned by the GeoIP Enterprise
     ///     database.
     /// </summary>
     public record EnterpriseResponse : AbstractCityResponse

--- a/MaxMind.GeoIP2/Responses/InsightsResponse.cs
+++ b/MaxMind.GeoIP2/Responses/InsightsResponse.cs
@@ -11,7 +11,7 @@ namespace MaxMind.GeoIP2.Responses
     {
         /// <summary>
         ///     Gets anonymizer-related data for the requested IP address.
-        ///     This is available from the GeoIP2 Insights web service.
+        ///     This is available from the GeoIP Insights web service.
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("anonymizer")]

--- a/MaxMind.GeoIP2/Responses/InsightsResponse.cs
+++ b/MaxMind.GeoIP2/Responses/InsightsResponse.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 namespace MaxMind.GeoIP2.Responses
 {
     /// <summary>
-    ///     This record provides a model for the data returned by the GeoIP2
+    ///     This record provides a model for the data returned by the GeoIP
     ///     Insights web service.
     /// </summary>
     public record InsightsResponse : AbstractCityResponse

--- a/MaxMind.GeoIP2/Responses/IspResponse.cs
+++ b/MaxMind.GeoIP2/Responses/IspResponse.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 namespace MaxMind.GeoIP2.Responses
 {
     /// <summary>
-    ///     This record represents the GeoIP2 ISP response.
+    ///     This record represents the GeoIP ISP response.
     /// </summary>
     public record IspResponse : AbstractResponse
     {

--- a/MaxMind.GeoIP2/WebServiceClient.cs
+++ b/MaxMind.GeoIP2/WebServiceClient.cs
@@ -21,7 +21,7 @@ namespace MaxMind.GeoIP2
 {
     /// <summary>
     ///     <para>
-    ///         This class provides a client API for all the GeoIP2 web services. The
+    ///         This class provides a client API for all the GeoIP web services. The
     ///         services are Country, City Plus, and Insights. Each service returns a
     ///         different set of data about an IP address, with Country returning the
     ///         least data and Insights the most.
@@ -62,7 +62,7 @@ namespace MaxMind.GeoIP2
     ///     <para>
     ///         For details on the possible errors returned by the web service itself,
     ///         see <a href="https://dev.maxmind.com/geoip/docs/web-services?lang=en">the
-    ///         GeoIP2 web service documentation</a>.
+    ///         GeoIP web service documentation</a>.
     ///     </para>
     /// </summary>
     public class WebServiceClient : IGeoIP2WebServicesClient, IDisposable
@@ -112,9 +112,9 @@ namespace MaxMind.GeoIP2
         /// <param name="locales">List of locale codes to use in name
         ///     property from most preferred to least preferred.</param>
         /// <param name="host">The host to use when accessing the service. Set this to
-        ///     "geolite.info" to use the GeoLite2 web service instead of GeoIP2.
-        ///     Set this to "sandbox.maxmind.com" to use the Sandbox GeoIP2 web service
-        ///     instead of the production GeoIP2 web service. The sandbox allows you to
+        ///     "geolite.info" to use the GeoLite web service instead of GeoIP.
+        ///     Set this to "sandbox.maxmind.com" to use the Sandbox GeoIP web service
+        ///     instead of the production GeoIP web service. The sandbox allows you to
         ///     experiment with the API without affecting your production data.</param>
         /// <param name="timeout">Timeout in milliseconds for connection to
         ///     web service. The default is 3000.</param>
@@ -224,8 +224,8 @@ namespace MaxMind.GeoIP2
 
         /// <summary>
         ///     Asynchronously query the Insights web service for the specified IP
-        ///     address. Please note that only the GeoIP2 web services support
-        ///     Insights. The GeoLite2 web services do not support it.
+        ///     address. Please note that only the GeoIP web services support
+        ///     Insights. The GeoLite web services do not support it.
         /// </summary>
         /// <param name="ipAddress">The IP address.</param>
         /// <returns>Task that produces an object modeling the Insights response</returns>
@@ -236,8 +236,8 @@ namespace MaxMind.GeoIP2
 
         /// <summary>
         ///     Asynchronously query the Insights web service for the specified IP
-        ///     address. Please note that only the GeoIP2 web services support
-        ///     Insights. The GeoLite2 web services do not support it.
+        ///     address. Please note that only the GeoIP web services support
+        ///     Insights. The GeoLite web services do not support it.
         /// </summary>
         /// <param name="ipAddress">The IP address.</param>
         /// <returns>Task that produces an object modeling the Insights response</returns>
@@ -248,8 +248,8 @@ namespace MaxMind.GeoIP2
 
         /// <summary>
         ///     Asynchronously query the Insights web service for the requesting IP
-        ///     address. Please note that only the GeoIP2 web services support
-        ///     Insights. The GeoLite2 web services do not support it.
+        ///     address. Please note that only the GeoIP web services support
+        ///     Insights. The GeoLite web services do not support it.
         /// </summary>
         /// <returns>Task that produces an object modeling the Insights response</returns>
         public async Task<InsightsResponse> InsightsAsync()
@@ -317,8 +317,8 @@ namespace MaxMind.GeoIP2
 
         /// <summary>
         ///     Returns an <see cref="InsightsResponse" /> for the specified IP
-        ///     address. Please note that only the GeoIP2 web services support
-        ///     Insights. The GeoLite2 web services do not support it.
+        ///     address. Please note that only the GeoIP web services support
+        ///     Insights. The GeoLite web services do not support it.
         /// </summary>
         /// <param name="ipAddress">The IP address.</param>
         /// <returns>An <see cref="InsightsResponse" /></returns>
@@ -329,8 +329,8 @@ namespace MaxMind.GeoIP2
 
         /// <summary>
         ///     Returns an <see cref="InsightsResponse" /> for the specified IP
-        ///     address. Please note that only the GeoIP2 web services support
-        ///     Insights. The GeoLite2 web services do not support it.
+        ///     address. Please note that only the GeoIP web services support
+        ///     Insights. The GeoLite web services do not support it.
         /// </summary>
         /// <param name="ipAddress">The IP address.</param>
         /// <returns>An <see cref="InsightsResponse" /></returns>
@@ -341,8 +341,8 @@ namespace MaxMind.GeoIP2
 
         /// <summary>
         ///     Returns an <see cref="InsightsResponse" /> for the requesting IP
-        ///     address. Please note that only the GeoIP2 web services support
-        ///     Insights. The GeoLite2 web services do not support it.
+        ///     address. Please note that only the GeoIP web services support
+        ///     Insights. The GeoLite web services do not support it.
         /// </summary>
         /// <returns>An <see cref="InsightsResponse" /></returns>
         public InsightsResponse Insights()

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# GeoIP2 .NET API
+# GeoIP .NET API
 
 [![NuGet](https://img.shields.io/nuget/v/MaxMind.GeoIP2)](https://www.nuget.org/packages/MaxMind.GeoIP2)
 
 ## Description
 
-This distribution provides an API for the GeoIP2 and GeoLite2
+This distribution provides an API for the GeoIP and GeoLite
 [web services](https://dev.maxmind.com/geoip/docs/web-services?lang=en) and
 [databases](https://dev.maxmind.com/geoip/docs/databases?lang=en).
 
@@ -22,7 +22,7 @@ install-package MaxMind.GeoIP2
 ## IP Geolocation Usage
 
 IP geolocation is inherently imprecise. Locations are often near the center of
-the population. Any location provided by a GeoIP2 database or web service should
+the population. Any location provided by a GeoIP database or web service should
 not be used to identify a particular address or household.
 
 ## Web Service Usage
@@ -34,13 +34,13 @@ your account ID and license key:
 var client = new WebServiceClient(42, "license_key1");
 ```
 
-To query the GeoLite2 web service, you must set the host to `geolite.info`:
+To query the GeoLite web service, you must set the host to `geolite.info`:
 
 ```
 var client = new WebServiceClient(42, "license_key1", host: "geolite.info");
 ```
 
-To query the Sandbox GeoIP2 web service, you must set the host to
+To query the Sandbox GeoIP web service, you must set the host to
 `sandbox.maxmind.com`:
 
 ```
@@ -94,9 +94,9 @@ builder.Services.AddHttpClient<WebServiceClient>();
     // Optionally set a timeout. The default is 3000 ms.
     // "Timeout": 3000,
 
-    // Optionally set host. "geolite.info" will use the GeoLite2
-    // web service instead of GeoIP2. "sandbox.maxmind.com" will use the
-    // Sandbox GeoIP2 web service instead of the production GeoIP2 web
+    // Optionally set host. "geolite.info" will use the GeoLite
+    // web service instead of GeoIP. "sandbox.maxmind.com" will use the
+    // Sandbox GeoIP web service instead of the production GeoIP web
     // service.
     //
     // "Host": "geolite.info"
@@ -138,10 +138,10 @@ public class MaxMindController : ControllerBase
 // class is thread safe.
 //
 // Replace "42" with your account ID and "license_key" with your license
-// key. Set the named host argument to "geolite.info" to use the GeoLite2
-// web service instead of GeoIP2. Set the named host argument to
-// "sandbox.maxmind.com" to use the Sandbox GeoIP2 web service instead of
-// the production GeoIP2 web service.
+// key. Set the named host argument to "geolite.info" to use the GeoLite
+// web service instead of GeoIP. Set the named host argument to
+// "sandbox.maxmind.com" to use the Sandbox GeoIP web service instead of
+// the production GeoIP web service.
 using (var client = new WebServiceClient(42, "license_key"))
 {
     // Do the lookup
@@ -161,10 +161,10 @@ using (var client = new WebServiceClient(42, "license_key"))
 // class is thread safe.
 //
 // Replace "42" with your account ID and "license_key" with your license
-// key. Set the named host argument to "geolite.info" to use the GeoLite2
-// web service instead of GeoIP2. Set the named host argument to
-// "sandbox.maxmind.com" to use the Sandbox GeoIP2 web service instead of
-// the production GeoIP2 web service.
+// key. Set the named host argument to "geolite.info" to use the GeoLite
+// web service instead of GeoIP. Set the named host argument to
+// "sandbox.maxmind.com" to use the Sandbox GeoIP web service instead of
+// the production GeoIP web service.
 using (var client = new WebServiceClient(42, "license_key"))
 {
     // Do the lookup
@@ -184,10 +184,10 @@ using (var client = new WebServiceClient(42, "license_key"))
 // class is thread safe.
 //
 // Replace "42" with your account ID and "license_key" with your license
-// key. Set the named host argument to "geolite.info" to use the GeoLite2
-// web service instead of GeoIP2. Set the named host argument to
-// "sandbox.maxmind.com" to use the Sandbox GeoIP2 web service instead of
-// the production GeoIP2 web service.
+// key. Set the named host argument to "geolite.info" to use the GeoLite
+// web service instead of GeoIP. Set the named host argument to
+// "sandbox.maxmind.com" to use the Sandbox GeoIP web service instead of
+// the production GeoIP web service.
 using (var client = new WebServiceClient(42, "license_key"))
 {
     // Do the lookup
@@ -217,10 +217,10 @@ using (var client = new WebServiceClient(42, "license_key"))
 // class is thread safe.
 //
 // Replace "42" with your account ID and "license_key" with your license
-// key. Set the named host argument to "geolite.info" to use the GeoLite2
-// web service instead of GeoIP2. Set the named host argument to
-// "sandbox.maxmind.com" to use the Sandbox GeoIP2 web service instead of
-// the production GeoIP2 web service.
+// key. Set the named host argument to "geolite.info" to use the GeoLite
+// web service instead of GeoIP. Set the named host argument to
+// "sandbox.maxmind.com" to use the Sandbox GeoIP web service instead of
+// the production GeoIP web service.
 using (var client = new WebServiceClient(42, "license_key"))
 {
     // Do the lookup
@@ -250,9 +250,9 @@ using (var client = new WebServiceClient(42, "license_key"))
 // class is thread safe.
 //
 // Replace "42" with your account ID and "license_key" with your license
-// key. The GeoLite2 web service does not support Insights. Set the named
-// host argument to "sandbox.maxmind.com" to use the Sandbox GeoIP2 web
-// service instead of the production GeoIP2 web service.
+// key. The GeoLite web service does not support Insights. Set the named
+// host argument to "sandbox.maxmind.com" to use the Sandbox GeoIP web
+// service instead of the production GeoIP web service.
 using (var client = new WebServiceClient(42, "license_key"))
 {
     // Do the lookup
@@ -282,9 +282,9 @@ using (var client = new WebServiceClient(42, "license_key"))
 // class is thread safe.
 //
 // Replace "42" with your account ID and "license_key" with your license
-// key. The GeoLite2 web service does not support Insights. Set the named
-// host argument to "sandbox.maxmind.com" to use the Sandbox GeoIP2 web
-// service instead of the production GeoIP2 web service.
+// key. The GeoLite web service does not support Insights. Set the named
+// host argument to "sandbox.maxmind.com" to use the Sandbox GeoIP web
+// service instead of the production GeoIP web service.
 using (var client = new WebServiceClient(42, "license_key"))
 {
     // Do the lookup
@@ -309,12 +309,12 @@ using (var client = new WebServiceClient(42, "license_key"))
 ## Database Usage
 
 To use the database API, you must create a new `DatabaseReader` with a string
-representation of the path to your GeoIP2 database. You may also specify the
+representation of the path to your GeoIP database. You may also specify the
 file access mode. You may then call the appropriate method (e.g., `city`) for
 your database, passing it the IP address you want to look up.
 
 If the lookup succeeds, the method call will return a response class for the
-GeoIP2 lookup. This class in turn contains multiple model classes, each of which
+GeoIP lookup. This class in turn contains multiple model classes, each of which
 represents part of the data returned by the database.
 
 We recommend reusing the `DatabaseReader` object rather than creating a new one
@@ -488,7 +488,7 @@ will be thrown.
 ### Web Service
 
 For details on the possible errors returned by the web service itself,
-[see the GeoIP2 web service documentation](https://dev.maxmind.com/geoip/docs/web-services?lang=en).
+[see the GeoIP web service documentation](https://dev.maxmind.com/geoip/docs/web-services?lang=en).
 
 If the web service returns an explicit error document, this is thrown as a
 `AddressNotFoundException`, a `AuthenticationException`, a
@@ -535,7 +535,7 @@ Because of these factors, it is possible for any end point to return a record
 where some or all of the attributes are unpopulated.
 
 See the
-[GeoIP2 web services documentation](https://dev.maxmind.com/geoip/docs/web-services?lang=en)
+[GeoIP web services documentation](https://dev.maxmind.com/geoip/docs/web-services?lang=en)
 for details on what data each end point may return.
 
 The only piece of data which is always returned is the `ipAddress` attribute in
@@ -548,7 +548,7 @@ databases with data on geographical features around the world, including
 populated places. They offer both free and paid premium data. Each feature is
 uniquely identified by a `geonameId`, which is an integer.
 
-Many of the records returned by the GeoIP2 web services and databases include a
+Many of the records returned by the GeoIP web services and databases include a
 `geonameId` property. This is the ID of a geographical feature (city, region,
 country, etc.) in the GeoNames database.
 

--- a/README.md
+++ b/README.md
@@ -309,9 +309,9 @@ using (var client = new WebServiceClient(42, "license_key"))
 ## Database Usage
 
 To use the database API, you must create a new `DatabaseReader` with a string
-representation of the path to your GeoIP database. You may also specify the
-file access mode. You may then call the appropriate method (e.g., `city`) for
-your database, passing it the IP address you want to look up.
+representation of the path to your GeoIP database. You may also specify the file
+access mode. You may then call the appropriate method (e.g., `city`) for your
+database, passing it the IP address you want to look up.
 
 If the lookup succeeds, the method call will return a response class for the
 GeoIP lookup. This class in turn contains multiple model classes, each of which

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -1,4 +1,4 @@
-title = "MaxMind GeoIP2 .NET API"
+title = "MaxMind GeoIP .NET API"
 disableKinds = ["taxonomy", "term", "RSS"]
 
 [[cascade]]


### PR DESCRIPTION
Updates prose/documentation to refer to the products as "GeoIP" and "GeoLite" instead of "GeoIP2"/"GeoLite2". Technical identifiers (namespaces, class names, .mmdb filenames, edition IDs, the geolite.info hostname, URLs) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)