### PR TITLE
Validate and update links (STF-557)

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,32 @@
+name: Links
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 13 * * 1" # weekly, to catch external link rot without a commit
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup mise
+        uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
+        with:
+          install: false
+
+      # Install only lychee (not the repo's full toolchain) and run the check.
+      - name: Check links
+        env:
+          MISE_AUTO_INSTALL: "false"
+        run: |
+          mise install lychee
+          mise run check-links

--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ UpgradeLog*.XML
 # Hugo docs build output
 docs/.hugo_build.lock
 docs/public/
+
+# lychee link checker cache
+.lycheecache

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,8 +210,8 @@ Always update `releasenotes.md` for user-facing changes:
 ## Additional Resources
 
 - [API Documentation](https://maxmind.github.io/GeoIP2-dotnet/)
-- [GeoIP Web Services Docs](https://dev.maxmind.com/geoip/docs/web-services?lang=en)
-- [GeoIP Database Docs](https://dev.maxmind.com/geoip/docs/databases?lang=en)
+- [GeoIP Web Services Docs](https://dev.maxmind.com/geoip/docs/web-services/?lang=en)
+- [GeoIP Database Docs](https://dev.maxmind.com/geoip/docs/databases/?lang=en)
 - [MaxMind DB Format](https://maxmind.github.io/MaxMind-DB/)
 - GitHub Issues: https://github.com/maxmind/GeoIP2-dotnet/issues
 

--- a/MaxMind.GeoIP2/WebServiceClient.cs
+++ b/MaxMind.GeoIP2/WebServiceClient.cs
@@ -61,7 +61,7 @@ namespace MaxMind.GeoIP2
     ///     </para>
     ///     <para>
     ///         For details on the possible errors returned by the web service itself,
-    ///         see <a href="https://dev.maxmind.com/geoip/docs/web-services?lang=en">the
+    ///         see <a href="https://dev.maxmind.com/geoip/docs/web-services/?lang=en">the
     ///         GeoIP web service documentation</a>.
     ///     </para>
     /// </summary>

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 ## Description
 
 This distribution provides an API for the GeoIP and GeoLite
-[web services](https://dev.maxmind.com/geoip/docs/web-services?lang=en) and
-[databases](https://dev.maxmind.com/geoip/docs/databases?lang=en).
+[web services](https://dev.maxmind.com/geoip/docs/web-services/?lang=en) and
+[databases](https://dev.maxmind.com/geoip/docs/databases/?lang=en).
 
 ## Installation
 
@@ -69,7 +69,7 @@ See the API documentation for more details.
 ### ASP.NET Core Usage
 
 To use the web service API with HttpClient factory pattern as a
-[Typed client](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/http-requests#typed-clients)
+[Typed client](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/http-requests?view=aspnetcore-10.0#typed-clients)
 you need to do the following:
 
 1. Add the following lines to `Program.cs`:
@@ -488,7 +488,7 @@ will be thrown.
 ### Web Service
 
 For details on the possible errors returned by the web service itself,
-[see the GeoIP web service documentation](https://dev.maxmind.com/geoip/docs/web-services?lang=en).
+[see the GeoIP web service documentation](https://dev.maxmind.com/geoip/docs/web-services/?lang=en).
 
 If the web service returns an explicit error document, this is thrown as a
 `AddressNotFoundException`, a `AuthenticationException`, a
@@ -535,7 +535,7 @@ Because of these factors, it is possible for any end point to return a record
 where some or all of the attributes are unpopulated.
 
 See the
-[GeoIP web services documentation](https://dev.maxmind.com/geoip/docs/web-services?lang=en)
+[GeoIP web services documentation](https://dev.maxmind.com/geoip/docs/web-services/?lang=en)
 for details on what data each end point may return.
 
 The only piece of data which is always returned is the `ipAddress` attribute in
@@ -559,7 +559,7 @@ premium data set.
 ## Reporting data problems
 
 If the problem you find is that an IP address is incorrectly mapped, please
-[submit your correction to MaxMind](https://www.maxmind.com/en/correction).
+[submit your correction to MaxMind](https://www.maxmind.com/en/geoip-data-correction-request).
 
 If you find some other sort of mistake, like an incorrect spelling, please check
 the [GeoNames site](https://www.geonames.org/) first. Once you've searched for a
@@ -569,8 +569,8 @@ correction is part of the GeoNames data set, it will be automatically
 incorporated into future MaxMind releases.
 
 If you are a paying MaxMind customer and you're not sure where to submit a
-correction, please [contact MaxMind support](https://www.maxmind.com/en/support)
-for help.
+correction, please
+[contact MaxMind support](https://support.maxmind.com/knowledge-base) for help.
 
 ## Other Support
 
@@ -578,7 +578,8 @@ Please report all issues with this code using the
 [GitHub issue tracker](https://github.com/maxmind/GeoIP2-dotnet/issues).
 
 If you are having an issue with a MaxMind service that is not specific to the
-client API, please see [our support page](https://www.maxmind.com/en/support).
+client API, please see
+[our support page](https://support.maxmind.com/knowledge-base).
 
 ## Contributing
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,65 @@
+# Lychee link checker configuration
+# https://lychee.cli.rs/#/usage/config
+#
+# Run locally with:
+#   lychee './**/*.md' './**/*.cs' './MaxMind.GeoIP2/MaxMind.GeoIP2.csproj'
+
+# Include URL fragments in checks
+include_fragments = true
+
+# Don't allow any redirects, so links that have moved are surfaced and can be
+# updated to their canonical destination.
+max_redirects = 0
+
+# Accept these HTTP status codes
+# 100-103: Informational responses
+# 200-299: Success responses
+# 403: Forbidden (some sites use this for rate limiting)
+# 429: Too Many Requests
+# 500-599: Server errors (temporary issues shouldn't fail CI)
+# 999: LinkedIn's custom status code
+accept = ["100..=103", "200..=299", "403", "429", "500..=599", "999"]
+
+# Exclude URL patterns from checking (treated as regular expressions)
+exclude = [
+    # GitHub blob URLs with line-number fragments (not parseable as page anchors)
+    '^https://github\.com/[^/]+/[^/]+/blob/[0-9a-fA-F]+/.+#L\d+$',
+    # Live / auth-gated MaxMind endpoints: appear as code string literals or
+    # require login, so they can't be verified by an anonymous request.
+    '^https://geoip\.maxmind\.com',
+    '^https://geolite\.info',
+    '^https://minfraud\.maxmind\.com',
+    '^https://sandbox\.maxmind\.com',
+    '^https://updates\.maxmind\.com',
+    '^https://www\.maxmind\.com/en/accounts/',
+    '^https://www\.maxmind\.com/en/account/login',
+    # XML / build-tool namespace URIs (identifiers, not real links)
+    '^http://schemas\.',
+    '^https://schemas\.',
+    '^http://www\.w3\.org/',
+    # Local / placeholder URLs (e.g. proxy examples in docs)
+    '^file://',
+    '^https?://example\.(com|org|net)',
+    '^http://localhost',
+    '127\.0\.0\.1',
+]
+
+# Exclude file paths from getting checked (regular expressions, matched against
+# the path relative to the working directory). Patterns are segment-anchored
+# with (^|/) so short names like "bin" don't match unintended paths.
+exclude_path = [
+    '(^|/)bin/',
+    '(^|/)obj/',
+    '(^|/)\.worktrees/',
+    '(^|/)docs/public/',
+    '(^|/)TestData/',
+    # Changelog: historical entries are preserved as-is, not rewritten
+    '(^|/)releasenotes\.md$',
+]
+
+# Cache results for 1 day to speed up repeated checks
+cache = true
+max_cache_age = "1d"
+
+# Skip missing input files instead of erroring
+skip_missing = true

--- a/mise.lock
+++ b/mise.lock
@@ -5,11 +5,11 @@ version = "10.0.201"
 backend = "core:dotnet"
 
 [[tools.dotnet]]
-version = "9.0.312"
+version = "8.0.419"
 backend = "core:dotnet"
 
 [[tools.dotnet]]
-version = "8.0.419"
+version = "9.0.312"
 backend = "core:dotnet"
 
 [[tools."github:houseabsolute/precious"]]
@@ -82,6 +82,34 @@ url = "https://github.com/gohugoio/hugo/releases/download/v0.161.1/hugo_0.161.1_
 [tools.hugo."platforms.windows-x64"]
 checksum = "sha256:7f8d030b37600c60bf2a782611257e6a768934fbe7724c1f3a1a501e6724cf0d"
 url = "https://github.com/gohugoio/hugo/releases/download/v0.161.1/hugo_0.161.1_windows-amd64.zip"
+
+[[tools.lychee]]
+version = "0.23.0"
+backend = "aqua:lycheeverse/lychee"
+
+[tools.lychee."platforms.linux-arm64"]
+checksum = "sha256:97eb93b02a7d78a752fc33e5b0983439ccaadbf3db952b68a0a4401acd92e6e0"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-aarch64-unknown-linux-gnu.tar.gz"
+
+[tools.lychee."platforms.linux-arm64-musl"]
+checksum = "sha256:97eb93b02a7d78a752fc33e5b0983439ccaadbf3db952b68a0a4401acd92e6e0"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-aarch64-unknown-linux-gnu.tar.gz"
+
+[tools.lychee."platforms.linux-x64"]
+checksum = "sha256:5538440d2c69a45a0a09983271e5dee0c2fe7137d8035d25b2632e10a66a090a"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-x86_64-unknown-linux-musl.tar.gz"
+
+[tools.lychee."platforms.linux-x64-musl"]
+checksum = "sha256:5538440d2c69a45a0a09983271e5dee0c2fe7137d8035d25b2632e10a66a090a"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-x86_64-unknown-linux-musl.tar.gz"
+
+[tools.lychee."platforms.macos-arm64"]
+checksum = "sha256:4c8034900e11083b68ac6f6582c377ff1f704e268991999e09d717973e493e7f"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-arm64-macos.dmg"
+
+[tools.lychee."platforms.windows-x64"]
+checksum = "sha256:0fda7ff0a60c0250939fc25361c2d4e6e7853c31c996733fdd5a1dd760bcb824"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-x86_64-windows.exe"
 
 [[tools.node]]
 version = "26.1.0"

--- a/mise.toml
+++ b/mise.toml
@@ -10,6 +10,7 @@ disable_backends = [
 dotnet = ["latest", "9", "8"]
 hugo = "latest"
 "github:houseabsolute/precious" = "latest"
+lychee = "latest"
 node = "latest"
 "npm:prettier" = "latest"
 
@@ -20,6 +21,10 @@ run = "hugo --source docs --minify"
 [tasks.serve-docs]
 description = "Serve the docs site locally with Hugo dev server"
 run = "hugo server --source docs"
+
+[tasks.check-links]
+description = "Check links with lychee"
+run = "lychee --no-progress './**/*.md' './**/*.cs' './MaxMind.GeoIP2/MaxMind.GeoIP2.csproj'"
 
 [hooks]
 enter = "mise install --quiet --locked"


### PR DESCRIPTION
Adds a lychee link checker configuration (`lychee.toml`) and a `Links`
GitHub Actions workflow (push, pull_request, weekly schedule,
workflow_dispatch) so stale or redirecting links are caught
automatically going forward. `max_redirects = 0` surfaces moved links so
they can be updated to their canonical destination.

Validated all links with lychee and updated those that were out of date
or redirecting:

- `https://dev.maxmind.com/geoip/docs/web-services?lang=en` -> `https://dev.maxmind.com/geoip/docs/web-services/?lang=en` (README.md, CLAUDE.md, MaxMind.GeoIP2/WebServiceClient.cs)
- `https://dev.maxmind.com/geoip/docs/databases?lang=en` -> `https://dev.maxmind.com/geoip/docs/databases/?lang=en` (README.md, CLAUDE.md)
- `https://learn.microsoft.com/en-us/aspnet/core/fundamentals/http-requests#typed-clients` -> `https://learn.microsoft.com/en-us/aspnet/core/fundamentals/http-requests?view=aspnetcore-10.0#typed-clients` (README.md)
- `https://www.maxmind.com/en/correction` -> `https://www.maxmind.com/en/geoip-data-correction-request` (README.md)
- `https://www.maxmind.com/en/support` -> `https://support.maxmind.com/knowledge-base` (README.md)

Historical `releasenotes.md` entries are intentionally excluded from
scanning and left unchanged.

Final lychee summary: 30 Total, 30 OK, 0 Errors. `precious lint --all`
passes.

Part of STF-557.

🤖 Generated with [Claude Code](https://claude.com/claude-code)