### PR TITLE
Add residential proxy data to Anonymizer

### DIFF
--- a/MaxMind.GeoIP2.UnitTests/DeserializationTests.cs
+++ b/MaxMind.GeoIP2.UnitTests/DeserializationTests.cs
@@ -1,4 +1,5 @@
 using MaxMind.GeoIP2.Responses;
+using System;
 using System.Text;
 using System.Text.Json;
 using Xunit;
@@ -37,6 +38,12 @@ namespace MaxMind.GeoIP2.UnitTests
 
         private static void CanDeserializeInsightsResponse(InsightsResponse insights)
         {
+            Assert.Equal(82, insights.Anonymizer.Residential.Confidence);
+#if NET6_0_OR_GREATER
+            Assert.Equal(new DateOnly(2026, 5, 11), insights.Anonymizer.Residential.NetworkLastSeen);
+#endif
+            Assert.Equal("quickshift", insights.Anonymizer.Residential.ProviderName);
+
             Assert.Equal(76, insights.City.Confidence);
             Assert.Equal(9876, insights.City.GeoNameId);
             Assert.Equal("Minneapolis", insights.City.Name);

--- a/MaxMind.GeoIP2.UnitTests/ResponseHelper.cs
+++ b/MaxMind.GeoIP2.UnitTests/ResponseHelper.cs
@@ -4,6 +4,13 @@
     {
         public static string InsightsJson = """
                 {
+                    "anonymizer": {
+                        "residential": {
+                            "confidence": 82,
+                            "network_last_seen": "2026-05-11",
+                            "provider_name": "quickshift"
+                        }
+                    },
                     "city": {
                         "confidence": 76,
                         "geoname_id": 9876,

--- a/MaxMind.GeoIP2/Model/Anonymizer.cs
+++ b/MaxMind.GeoIP2/Model/Anonymizer.cs
@@ -93,5 +93,16 @@ namespace MaxMind.GeoIP2.Model
         [JsonInclude]
         [JsonPropertyName("provider_name")]
         public string? ProviderName { get; init; }
+
+        /// <summary>
+        ///     Residential proxy data for the network. This may be populated
+        ///     even when none of the other properties are set. If there is
+        ///     no residential proxy data for the network, this will be an
+        ///     empty object. This is available from the GeoIP Insights web
+        ///     service.
+        /// </summary>
+        [JsonInclude]
+        [JsonPropertyName("residential")]
+        public AnonymizerFeed Residential { get; init; } = new();
     }
 }

--- a/MaxMind.GeoIP2/Model/AnonymizerFeed.cs
+++ b/MaxMind.GeoIP2/Model/AnonymizerFeed.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace MaxMind.GeoIP2.Model
+{
+    /// <summary>
+    ///     Contains data for one type of anonymizer detection, currently
+    ///     residential proxies. Additional feeds may be added in the
+    ///     future. This record is returned by the GeoIP Insights web
+    ///     service.
+    /// </summary>
+    public record AnonymizerFeed
+    {
+        /// <summary>
+        ///     A score ranging from 1 to 99 that represents our percent
+        ///     confidence that the network is currently part of this
+        ///     anonymizer feed. This is available from the GeoIP Insights
+        ///     web service.
+        /// </summary>
+        [JsonInclude]
+        [JsonPropertyName("confidence")]
+        public int? Confidence { get; init; }
+
+#if NET6_0_OR_GREATER
+        /// <summary>
+        ///     The last day that the network was sighted in our analysis of
+        ///     this anonymizer feed. This is available from the GeoIP
+        ///     Insights web service.
+        /// </summary>
+        [JsonInclude]
+        [JsonPropertyName("network_last_seen")]
+        public DateOnly? NetworkLastSeen { get; init; }
+#endif
+
+        /// <summary>
+        ///     The name of the provider associated with the network in this
+        ///     anonymizer feed. This is available from the GeoIP Insights
+        ///     web service.
+        /// </summary>
+        [JsonInclude]
+        [JsonPropertyName("provider_name")]
+        public string? ProviderName { get; init; }
+    }
+}

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -1,5 +1,16 @@
 # GeoIP2 .NET API Release Notes
 
+## 6.1.0 (TBD)
+
+- A new `Residential` property has been added to
+  `MaxMind.GeoIP2.Model.Anonymizer`. This is of the new
+  `MaxMind.GeoIP2.Model.AnonymizerFeed` record type and provides residential
+  proxy data for the network: `Confidence`, `NetworkLastSeen` (`DateOnly` on
+  .NET 6.0+), and `ProviderName`. `Anonymizer.Residential` may be populated even
+  when none of the other `Anonymizer` properties are set. If there is no
+  residential proxy data for the network, this will be an empty object. This is
+  available from the GeoIP Insights web service.
+
 ## 6.0.0 (2026-05-22)
 
 - First non-beta 6.0.0 release. See the `6.0.0-beta1` notes below for the


### PR DESCRIPTION
## Summary

The GeoIP Insights web service is adding a `residential` sub-object to the `anonymizer` object. It contains residential proxy data for the network and may be populated even when no other anonymizer properties are set.

- New reusable record for the feed shape (`confidence`, `network_last_seen`, `provider_name`) named `AnonymizerFeed`, so future anonymizer feeds can share it
- New `residential` property on the `Anonymizer` record
- Tests, fixtures, and changelog updated

`Residential` is non-nullable with an empty-object default, matching the library's existing sub-object pattern.

## Testing

`dotnet build` (all target frameworks) and `dotnet test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
