### PR TITLE
Avoid stack inspection in database reader

### DIFF
--- a/MaxMind.GeoIP2/DatabaseReader.cs
+++ b/MaxMind.GeoIP2/DatabaseReader.cs
@@ -5,7 +5,6 @@ using MaxMind.GeoIP2.Exceptions;
 using MaxMind.GeoIP2.Responses;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Net;
@@ -518,9 +517,8 @@ namespace MaxMind.GeoIP2
         {
             if (!Metadata.DatabaseType.Contains(type))
             {
-                var frame = new StackFrame(2, true);
                 throw new InvalidOperationException(
-                    $"A {Metadata.DatabaseType} database cannot be opened with the {frame.GetMethod()?.Name} method");
+                    $"A {Metadata.DatabaseType} database cannot be opened with the {type} lookup");
             }
 
             var injectables = new InjectableValues();

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -1,5 +1,11 @@
 # GeoIP2 .NET API Release Notes
 
+## 6.1.1 (TBD)
+
+- Database lookups no longer inspect the call stack when reporting that a
+  database does not support the requested lookup. This removes a trimming
+  warning and makes this error path compatible with Native AOT.
+
 ## 6.1.0 (2026-07-16)
 
 - A new `Residential` property has been added to


### PR DESCRIPTION
# Avoid stack inspection in database reader

## Summary

- Stop using `StackFrame.GetMethod()` to construct the unsupported-database
  lookup error.
- Report the requested database lookup type directly.
- Document the user-visible error-message change in the release notes.

This removes one trimming warning from the database reader without changing
lookup behavior. It is independent of the larger `MaxMind.Db` model-mapping
work and the separate source-generated JSON design needed by the web-service
client. The latter is tracked in #505.

## Verification

- 151 tests pass on `net8.0`.
- 151 tests pass on `net10.0`.
- With `IsAotCompatible=true` and
  `VerifyReferenceAotCompatibility=true`, the `StackFrame.GetMethod()` IL2026
  warning is gone. The five remaining warnings are the known `MaxMind.Db`
  reference warning and four reflection-based `System.Text.Json` warnings in
  `WebServiceClient`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for unsupported database lookups by identifying the requested lookup type.
  * Removed call-stack inspection from this error path, improving compatibility with trimming and Native AOT deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->