### PR TITLE
Validate package API against the latest release

### DIFF
--- a/MaxMind.GeoIP2/MaxMind.GeoIP2.csproj
+++ b/MaxMind.GeoIP2/MaxMind.GeoIP2.csproj
@@ -16,6 +16,7 @@
     <PackageProjectUrl>https://github.com/maxmind/GeoIP2-dotnet</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <EnablePackageValidation>true</EnablePackageValidation>
+    <PackageValidationBaselineVersion>6.1.0</PackageValidationBaselineVersion>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/maxmind/GeoIP2-dotnet</RepositoryUrl>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/dev-bin/release.sh
+++ b/dev-bin/release.sh
@@ -114,3 +114,12 @@ if [[ "$version" == *-* ]]; then
 fi
 
 gh release create "$tag" "${release_args[@]}"
+
+# Now that the release is tagged, validate future changes against it. The
+# package may not be downloadable from NuGet until several minutes after
+# the release workflow publishes it.
+sed -i "s|<PackageValidationBaselineVersion>[^<]*</PackageValidationBaselineVersion>|<PackageValidationBaselineVersion>$version</PackageValidationBaselineVersion>|" MaxMind.GeoIP2/MaxMind.GeoIP2.csproj
+
+git commit -m "Set package validation baseline to $version" -a
+
+git push


### PR DESCRIPTION
## What

Set `PackageValidationBaselineVersion` to 6.1.0 (the latest published release) in `MaxMind.GeoIP2.csproj`, and update `dev-bin/release.sh` to bump the baseline to the new version right after tagging a release.

## Why

`EnablePackageValidation` (already set) only runs the compatible-TFM validators on its own; it does not compare the package against the previously published release, so an accidental breaking API change still packs successfully. With `PackageValidationBaselineVersion` set, `dotnet pack` downloads the baseline package from NuGet and fails on binary- or source-incompatible changes. Since the release workflow runs `dotnet pack` on every pull request, accidental breaking changes are caught in CI (STF-55).

The baseline is bumped *after* tagging so that pull requests are always validated against the latest published release, while the tagged commit itself is validated against the release it replaces (the new version is not yet on NuGet when the release build packs). One caveat: packs that run in the few minutes between tagging and the package becoming downloadable from NuGet can fail transiently; a re-run fixes them.

Verified locally: `dotnet pack` on this branch passes against the 6.1.0 baseline, and in a sibling repo an intentional breaking change (making a public property internal) fails pack with `CP0002` for every TFM. Intentional breaking changes (e.g., for a future major release) can be recorded with `dotnet pack /p:ApiCompatGenerateSuppressionFile=true`.

Same change as maxmind/minfraud-api-dotnet#445.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Set the NuGet package validation baseline version to **6.1.0**.
  * Updated the release workflow to automatically set the package validation baseline to the **current release version** after publishing, then commit and push the change.
  * Helps ensure each package release is validated against the most recently published version, reducing manual release configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->